### PR TITLE
Revert lost tests

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,4 @@
 ---
 exclude_paths:
   - "time/src/test/**/*.*"
+  - "testutil-time/src/test/**/*.*"

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,8 @@ ext {
 
     credentialsPropertyFile = 'credentials.properties'
     publishPlugin = "$rootDir/scripts/publish.gradle"
-    projectsToPublish = ["time"]
+    projectsToPublish = ["time",
+                         "testutil-time"]
 }
 
 allprojects {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'spine-time'
 
 include 'time'
+include 'testutil-time'
 

--- a/testutil-time/build.gradle
+++ b/testutil-time/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+dependencies {
+    // Depend on JUnit in the production part of the code, as this module exposes testing utilities
+    // that are based on JUnit.
+    compile group: 'junit', name: 'junit', version: jUnitVersion
+
+    // Depend on Mockito in the production code because this module exposes testing utilities
+    // based on this library.
+    compile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+    
+    // Depend on the base module that contains `Timestamps` and other utility classes.
+    compile project(path: ':time')
+
+    testCompile group: 'io.spine', name: 'spine-testutil-base', version: spineBaseVersion
+}

--- a/testutil-time/src/main/java/io/spine/test/TimeTests.java
+++ b/testutil-time/src/main/java/io/spine/test/TimeTests.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.test;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import io.spine.time.Durations2;
+import io.spine.time.Time;
+
+import static com.google.protobuf.util.Durations.fromSeconds;
+import static com.google.protobuf.util.Timestamps.add;
+import static com.google.protobuf.util.Timestamps.subtract;
+import static io.spine.time.Durations2.hours;
+import static io.spine.time.Durations2.seconds;
+import static io.spine.time.Time.getCurrentTime;
+import static io.spine.time.Time.systemTime;
+import static io.spine.validate.Validate.checkPositive;
+
+/**
+ * Utility class for working with time-related tests.
+ *
+ * @author Alexander Yevsykov
+ */
+@VisibleForTesting
+public class TimeTests {
+
+    private TimeTests() {
+        // Prevent instantiation of this utility class.
+    }
+
+    /**
+     * Returns the {@linkplain Time#getCurrentTime() current time} in seconds.
+     *
+     * @return a seconds value
+     */
+    public static long currentTimeSeconds() {
+        final long secs = getCurrentTime().getSeconds();
+        return secs;
+    }
+
+    /**
+     * The provider of current time, which is always the same.
+     *
+     * <p>Use this {@code Timestamps.Provider} in time-related tests that are
+     * sensitive to bounds of minutes, hours, days, etc.
+     */
+    public static class FrozenMadHatterParty implements Time.Provider {
+        private final Timestamp frozenTime;
+
+        public FrozenMadHatterParty(Timestamp frozenTime) {
+            this.frozenTime = frozenTime;
+        }
+
+        /** Returns the value passed to the constructor. */
+        @Override
+        public Timestamp getCurrentTime() {
+            return frozenTime;
+        }
+    }
+
+    /**
+     * The time provider that can rewind current time.
+     *
+     * <p>Created in the future, {@linkplain #THIRTY_YEARS_IN_HOURS 30 years} from
+     * the {@link Time#systemTime() current system time}.
+     */
+    public static class BackToTheFuture implements Time.Provider {
+
+        public static final long THIRTY_YEARS_IN_HOURS = 262800L;
+
+        private Timestamp currentTime;
+
+        public BackToTheFuture() {
+            this.currentTime = add(systemTime(), hours(THIRTY_YEARS_IN_HOURS));
+        }
+
+        @Override
+        public synchronized Timestamp getCurrentTime() {
+            return this.currentTime;
+        }
+
+        private synchronized void setCurrentTime(Timestamp currentTime) {
+            this.currentTime = currentTime;
+        }
+
+        /**
+         * Rewinds the {@linkplain #getCurrentTime() "current time"} forward
+         * by the passed amount of hours.
+         */
+        public synchronized Timestamp forward(long hoursDelta) {
+            checkPositive(hoursDelta);
+            final Timestamp newTime = add(this.currentTime, hours(hoursDelta));
+            setCurrentTime(newTime);
+            return newTime;
+        }
+
+        /**
+         * Rewinds the {@linkplain #getCurrentTime() "current time"} backward
+         * by the passed amount of hours.
+         */
+        public synchronized Timestamp backward(long hoursDelta) {
+            checkPositive(hoursDelta);
+            final Timestamp newTime = subtract(this.currentTime, hours(hoursDelta));
+            setCurrentTime(newTime);
+            return newTime;
+        }
+    }
+
+    /**
+     * Utility class for working with timestamps in the past.
+     */
+    public static class Past {
+
+        private Past() {
+            // Do not allow creating instances of this utility class.
+        }
+
+        /**
+         * The testing assistance utility, which returns a timestamp of the moment
+         * of the passed number of minutes from now.
+         *
+         * @param value a positive number of minutes
+         * @return a timestamp instance
+         */
+        public static Timestamp minutesAgo(int value) {
+            checkPositive(value);
+            final Timestamp currentTime = getCurrentTime();
+            final Timestamp result = subtract(currentTime, Durations2.fromMinutes(value));
+            return result;
+        }
+
+        /**
+         * Obtains timestamp in the past a number of seconds ago.
+         *
+         * @param value a positive number of seconds
+         * @return the moment `value` seconds ago
+         */
+        public static Timestamp secondsAgo(long value) {
+            checkPositive(value);
+            final Timestamp currentTime = getCurrentTime();
+            final Timestamp result = subtract(currentTime, seconds(value));
+            return result;
+        }
+    }
+
+    /**
+     * Utility class for working with timestamps of the the future.
+     */
+    public static class Future {
+
+        private Future() {
+            // Do not allow creating instances of this utility class.
+        }
+
+        /**
+         * Obtains timestamp in the future a number of seconds from current time.
+         *
+         * @param seconds a positive number of seconds
+         * @return the moment which is {@code seconds} from now
+         */
+        public static Timestamp secondsFromNow(int seconds) {
+            checkPositive(seconds);
+            final Timestamp currentTime = getCurrentTime();
+            final Timestamp result = add(currentTime, fromSeconds(seconds));
+            return result;
+        }
+
+        /**
+         * Verifies if the passed timestamp is in the future comparing it
+         * with {@linkplain Time#systemTime() system time}.
+         */
+        public static boolean isFuture(Timestamp timestamp) {
+            // Do not use `getCurrentTime()` as we may use custom `TimestampProvider` already.
+            // Get time from metal.
+            final Timestamp currentSystemTime = systemTime();
+
+            // NOTE: we have the risk of having these two timestamps too close to each other
+            // so that the passed timestamp becomes "the past" around the time of this call.
+            // To avoid this, select some time in the "distant" future.
+            final boolean result = Timestamps.comparator()
+                                             .compare(currentSystemTime, timestamp) < 0;
+            return result;
+        }
+    }
+}

--- a/testutil-time/src/main/java/io/spine/test/TimeTests.java
+++ b/testutil-time/src/main/java/io/spine/test/TimeTests.java
@@ -177,7 +177,7 @@ public class TimeTests {
          * @param seconds a positive number of seconds
          * @return the moment which is {@code seconds} from now
          */
-        public static Timestamp secondsFromNow(int seconds) {
+        public static Timestamp secondsFromNow(long seconds) {
             checkPositive(seconds);
             final Timestamp currentTime = getCurrentTime();
             final Timestamp result = add(currentTime, fromSeconds(seconds));

--- a/testutil-time/src/test/java/io/spine/test/BackToTheFutureShould.java
+++ b/testutil-time/src/test/java/io/spine/test/BackToTheFutureShould.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.test;
+
+import io.spine.test.TimeTests.BackToTheFuture;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.spine.test.TimeTests.BackToTheFuture.THIRTY_YEARS_IN_HOURS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public class BackToTheFutureShould {
+
+    private BackToTheFuture timeProvider;
+
+    @Before
+    public void setUp() {
+        timeProvider = new BackToTheFuture();
+    }
+
+    @Test
+    public void create_with_start_in_the_future() {
+        assertTrue(TimeTests.Future.isFuture(timeProvider.getCurrentTime()));
+    }
+
+    @Test
+    public void rewind_backward() {
+        // Rewind to somewhere around present.
+        Assert.assertNotEquals(timeProvider.getCurrentTime(),
+                               timeProvider.backward(THIRTY_YEARS_IN_HOURS));
+
+        // ... and back to 30 years in the past.
+        timeProvider.backward(THIRTY_YEARS_IN_HOURS);
+
+        assertFalse(TimeTests.Future.isFuture(timeProvider.getCurrentTime()));
+    }
+
+    @SuppressWarnings("MagicNumber")
+    @Test
+    public void rewind_forward() {
+        // Rewind to somewhere around present.
+        timeProvider.backward(THIRTY_YEARS_IN_HOURS);
+
+        timeProvider.forward(THIRTY_YEARS_IN_HOURS + 24L);
+
+        assertTrue(TimeTests.Future.isFuture(timeProvider.getCurrentTime()));
+    }
+}

--- a/testutil-time/src/test/java/io/spine/test/TimeTestsShould.java
+++ b/testutil-time/src/test/java/io/spine/test/TimeTestsShould.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.test;
+
+import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.Timestamp;
+import io.spine.time.Time;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.google.protobuf.util.Timestamps.subtract;
+import static io.spine.time.Durations2.fromMinutes;
+import static io.spine.time.Time.getCurrentTime;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public class TimeTestsShould {
+
+    @Test
+    public void have_private_utility_ctor() {
+        Tests.assertHasPrivateParameterlessCtor(TimeTests.class);
+        Tests.assertHasPrivateParameterlessCtor(TimeTests.Future.class);
+        Tests.assertHasPrivateParameterlessCtor(TimeTests.Past.class);
+    }
+
+    @Test
+    public void pass_null_tolerance_check() {
+        new NullPointerTester()
+                .setDefault(Timestamp.class, getCurrentTime())
+                .testAllPublicStaticMethods(TimeTests.class);
+    }
+
+    @Test
+    public void have_frozen_time_provider() {
+        final Timestamp fiveMinutesAgo = subtract(getCurrentTime(),
+                                                  fromMinutes(5));
+
+        final Time.Provider provider =
+                new TimeTests.FrozenMadHatterParty(fiveMinutesAgo);
+
+        assertEquals(fiveMinutesAgo, provider.getCurrentTime());
+    }
+
+    @Test
+    public void return_current_time_in_seconds() {
+        Assert.assertNotEquals(0, TimeTests.currentTimeSeconds());
+    }
+}

--- a/time/build.gradle
+++ b/time/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     compile group: 'io.spine', name: 'spine-base', version: spineBaseVersion
 
     testCompile group: 'io.spine', name: 'spine-testutil-base', version: spineBaseVersion
+    testCompile project(path: ':testutil-time')
 }
 
 modelCompiler {

--- a/time/src/test/java/io/spine/time/Durations2Should.java
+++ b/time/src/test/java/io/spine/time/Durations2Should.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.time;
+
+import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.Duration;
+import io.spine.string.Stringifier;
+import io.spine.time.string.TimeStringifiers;
+import org.junit.Test;
+
+import static com.google.protobuf.util.Durations.subtract;
+import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.time.Durations2.ZERO;
+import static io.spine.time.Durations2.add;
+import static io.spine.time.Durations2.fromHours;
+import static io.spine.time.Durations2.fromMinutes;
+import static io.spine.time.Durations2.getHours;
+import static io.spine.time.Durations2.getMinutes;
+import static io.spine.time.Durations2.hoursAndMinutes;
+import static io.spine.time.Durations2.isGreaterThan;
+import static io.spine.time.Durations2.isLessThan;
+import static io.spine.time.Durations2.isNegative;
+import static io.spine.time.Durations2.isPositive;
+import static io.spine.time.Durations2.isPositiveOrZero;
+import static io.spine.time.Durations2.isZero;
+import static io.spine.time.Durations2.minutes;
+import static io.spine.time.Durations2.nanos;
+import static io.spine.time.Durations2.seconds;
+import static io.spine.time.Durations2.toMinutes;
+import static io.spine.time.Durations2.toNanos;
+import static io.spine.time.Durations2.toSeconds;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+@SuppressWarnings({"MagicNumber", "ClassWithTooManyMethods"})
+public class Durations2Should {
+
+    @Test
+    public void have_private_constructor() {
+        assertHasPrivateParameterlessCtor(Durations2.class);
+    }
+
+    @Test
+    public void have_ZERO_constant() {
+        assertEquals(0, toNanos(ZERO));
+    }
+
+    @Test(expected = ArithmeticException.class)
+    public void fail_to_convert_minutes_to_duration_if_input_is_too_big() {
+        fromMinutes(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void convert_hours_to_duration() {
+        testHourConversion(0);
+        testHourConversion(36);
+        testHourConversion(-384);
+    }
+
+    private static void testHourConversion(long hours) {
+        final Duration expected = seconds(hoursToSeconds(hours));
+        final Duration actual = fromHours(hours);
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = ArithmeticException.class)
+    public void fail_to_convert_hours_to_duration_if_input_is_too_big() {
+        fromHours(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void add_null_durations_return_zero() {
+        assertEquals(ZERO, add(null, null));
+    }
+
+    @Test
+    public void add_duration_and_null() {
+        final Duration duration = seconds(525);
+        assertEquals(duration, add(duration, null));
+        assertEquals(duration, add(null, duration));
+    }
+
+    @Test
+    public void add_positive_durations() {
+        addDurationsTest(25, 5);
+        addDurationsTest(300, 338);
+    }
+
+    @Test
+    public void add_negative_durations() {
+        addDurationsTest(-25, -5);
+        addDurationsTest(-300, -338);
+    }
+
+    @Test
+    public void add_negative_and_positive_durations() {
+        addDurationsTest(25, -5);
+        addDurationsTest(-300, 338);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fail_to_add_too_big_durations() {
+        add(seconds(Long.MAX_VALUE), seconds(256));
+    }
+
+    private static void addDurationsTest(long seconds1, long seconds2) {
+
+        final long secondsTotal = seconds1 + seconds2;
+        final Duration sumExpected = seconds(secondsTotal);
+
+        final Duration sumActual = add(seconds(seconds1), seconds(seconds2));
+
+        assertEquals(sumExpected, sumActual);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void fail_to_subtract_too_big_values() {
+        final Duration duration1 = seconds(Long.MAX_VALUE);
+        final Duration duration2 = seconds(Long.MAX_VALUE / 2);
+        subtract(duration1, duration2);
+    }
+
+    @Test
+    public void convert_hours_and_minutes_to_duration() {
+
+        final long hours = 3;
+        final long minutes = 25;
+        final long secondsTotal = hoursToSeconds(hours) + minutesToSeconds(minutes);
+        final Duration expected = seconds(secondsTotal);
+
+        final Duration actual = hoursAndMinutes(hours, minutes);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void convert_duration_to_nanoseconds() {
+        assertEquals(10, toNanos(nanos(10)));
+        assertEquals(-256, toNanos(nanos(-256)));
+    }
+
+    @Test
+    public void convert_duration_to_seconds() {
+        assertEquals(1, toSeconds(seconds(1)));
+        assertEquals(-256, toSeconds(seconds(-256)));
+    }
+
+    @Test
+    public void convert_duration_to_minutes() {
+        assertEquals(1, toMinutes(minutes(1)));
+        assertEquals(-256, toMinutes(minutes(-256)));
+    }
+
+    @Test
+    public void return_hours_from_duration() {
+        assertEquals(1, getHours(fromHours(1)));
+        assertEquals(-256, getHours(fromHours(-256)));
+    }
+
+    @Test
+    public void return_remainder_of_minutes_from_duration() {
+        final long minutesRemainder = 8;
+        final long minutesTotal = minutesRemainder + 60; // add 1 hour
+        assertEquals(minutesRemainder, getMinutes(fromMinutes(minutesTotal)));
+    }
+
+    @Test
+    public void verify_if_positive_or_zero() {
+        assertTrue(isPositiveOrZero(seconds(360)));
+        assertTrue(isPositiveOrZero(seconds(0)));
+        assertFalse(isPositiveOrZero(seconds(-32)));
+    }
+
+    @Test
+    public void verify_if_positive() {
+        assertTrue(isPositive(seconds(360)));
+        assertFalse(isPositive(seconds(0)));
+        assertFalse(isPositive(seconds(-32)));
+    }
+
+    @Test
+    public void verify_if_zero() {
+        assertTrue(isZero(seconds(0)));
+        assertFalse(isZero(seconds(360)));
+        assertFalse(isZero(seconds(-32)));
+    }
+
+    @Test
+    public void verify_if_negative() {
+        assertTrue(isNegative(seconds(-32)));
+        assertFalse(isNegative(seconds(360)));
+        assertFalse(isNegative(seconds(0)));
+    }
+
+    @Test
+    public void verify_if_greater() {
+        assertTrue(isGreaterThan(seconds(64), seconds(2)));
+        assertFalse(isGreaterThan(seconds(2), seconds(64)));
+        assertFalse(isGreaterThan(seconds(5), seconds(5)));
+    }
+
+    @Test
+    public void verify_if_less() {
+        assertTrue(isLessThan(seconds(2), seconds(64)));
+        assertFalse(isLessThan(seconds(64), seconds(2)));
+        assertFalse(isLessThan(seconds(5), seconds(5)));
+    }
+    
+    @Test
+    public void pass_the_null_tolerance_check() {
+        new NullPointerTester()
+                .setDefault(Duration.class, Duration.getDefaultInstance())
+                .testStaticMethods(Durations2.class, NullPointerTester.Visibility.PACKAGE);
+    }
+
+    private static long hoursToSeconds(long hours) {
+        return hours * 60L * 60L;
+    }
+
+    private static long minutesToSeconds(long minutes) {
+        return minutes * 60L;
+    }
+
+    @Test
+    public void provide_stringifier() {
+        final Stringifier<Duration> stringifier = TimeStringifiers.forDuration();
+        final Duration duration = hoursAndMinutes(10, 20);
+        assertEquals(duration, stringifier.reverse()
+                                          .convert(stringifier.convert(duration)));
+    }
+}

--- a/time/src/test/java/io/spine/time/Timestamps2Should.java
+++ b/time/src/test/java/io/spine/time/Timestamps2Should.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.time;
+
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import io.spine.test.TimeTests;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static com.google.protobuf.util.Durations.fromSeconds;
+import static com.google.protobuf.util.Timestamps.add;
+import static com.google.protobuf.util.Timestamps.subtract;
+import static com.google.protobuf.util.Timestamps.toNanos;
+import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.time.Durations2.fromMinutes;
+import static io.spine.time.Time.HOURS_PER_DAY;
+import static io.spine.time.Time.MICROS_PER_SECOND;
+import static io.spine.time.Time.MILLIS_PER_SECOND;
+import static io.spine.time.Time.NANOS_PER_MICROSECOND;
+import static io.spine.time.Time.NANOS_PER_SECOND;
+import static io.spine.time.Time.SECONDS_PER_HOUR;
+import static io.spine.time.Time.getCurrentTime;
+import static io.spine.time.Time.resetProvider;
+import static io.spine.time.Time.setProvider;
+import static io.spine.time.Time.systemTime;
+import static io.spine.time.Timestamps2.compare;
+import static io.spine.time.Timestamps2.isBetween;
+import static io.spine.time.Timestamps2.isLaterThan;
+import static io.spine.time.Timestamps2.toDate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Timestamps2Should {
+
+    private static final Duration TEN_SECONDS = fromSeconds(10L);
+
+    private static final Duration MINUTE = fromMinutes(1);
+
+    @Test
+    public void have_private_constructor() {
+        assertHasPrivateParameterlessCtor(Timestamps2.class);
+    }
+
+    @Test
+    public void declare_unit_constants() {
+        // Make these useful constant used from our library code to prevent
+        // accidental removal.
+        assertNotEquals(0, NANOS_PER_MICROSECOND);
+        assertNotEquals(0, MICROS_PER_SECOND);
+        assertNotEquals(0, SECONDS_PER_HOUR);
+        assertNotEquals(0, HOURS_PER_DAY);
+    }
+
+    @Test
+    public void calculate_timestamp_of_moment_minute_ago() {
+        final Timestamp currentTime = getCurrentTime();
+        final Timestamp expected = subtract(currentTime, MINUTE);
+
+        final Timestamp actual = TimeTests.Past.minutesAgo(1);
+
+        assertEquals(expected.getSeconds(), actual.getSeconds());
+    }
+
+    @Test
+    public void calculate_timestamp_of_moment_seconds_ago() {
+        final Timestamp currentTime = getCurrentTime();
+        final Timestamp expected = subtract(currentTime, TEN_SECONDS);
+
+        final Timestamp actual = TimeTests.Past.secondsAgo(TEN_SECONDS.getSeconds());
+
+        assertEquals(expected.getSeconds(), actual.getSeconds());
+    }
+
+    @Test
+    public void compare_two_timestamps_return_negative_int_if_first_less_than_second_one() {
+        final Timestamp time1 = getCurrentTime();
+        final Timestamp time2 = add(time1, TEN_SECONDS);
+
+        final int result = compare(time1, time2);
+
+        assertTrue(result < 0);
+    }
+
+    @Test
+    public void compare_two_timestamps_return_negative_int_if_first_is_null() {
+        final Timestamp currentTime = getCurrentTime();
+
+        final int result = compare(null, currentTime);
+
+        assertTrue(result < 0);
+    }
+
+    @Test
+    public void compare_two_timestamps_return_zero_if_timestamps_are_equal() {
+        final int secs = 256;
+        final int nanos = 512;
+        final Timestamp time1 = Timestamp.newBuilder()
+                                         .setSeconds(secs)
+                                         .setNanos(nanos)
+                                         .build();
+        final Timestamp time2 = Timestamp.newBuilder()
+                                         .setSeconds(secs)
+                                         .setNanos(nanos)
+                                         .build();
+
+        final int result = compare(time1, time2);
+
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void compare_two_timestamps_return_zero_if_pass_null() {
+        final int result = compare(null, null);
+
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void compare_two_timestamps_return_positive_int_if_first_greater_than_second_one() {
+        final Timestamp currentTime = getCurrentTime();
+        final Timestamp timeAfterCurrent = add(currentTime, TEN_SECONDS);
+
+        final int result = compare(timeAfterCurrent, currentTime);
+
+        assertTrue(result > 0);
+    }
+
+    @Test
+    public void compare_two_timestamps_return_positive_int_if_second_one_is_null() {
+        final Timestamp currentTime = getCurrentTime();
+
+        final int result = compare(currentTime, null);
+
+        assertTrue(result > 0);
+    }
+
+    @Test
+    public void return_true_if_timestamp_is_between_two_timestamps() {
+        final Timestamp start = getCurrentTime();
+        final Timestamp timeBetween = add(start, TEN_SECONDS);
+        final Timestamp finish = add(timeBetween, TEN_SECONDS);
+
+        final boolean isBetween = isBetween(timeBetween, start, finish);
+
+        assertTrue(isBetween);
+    }
+
+    @Test
+    public void return_false_if_timestamp_is_not_between_two_timestamps() {
+        final Timestamp start = getCurrentTime();
+        final Timestamp finish = add(start, TEN_SECONDS);
+        final Timestamp timeNotBetween = add(finish, TEN_SECONDS);
+
+        final boolean isBetween = isBetween(timeNotBetween, start, finish);
+
+        assertFalse(isBetween);
+    }
+
+    @Test
+    public void return_true_if_timestamp_is_after_another_one() {
+        final Timestamp fromPoint = getCurrentTime();
+        final Timestamp timeToCheck = add(fromPoint, TEN_SECONDS);
+
+        final boolean isAfter = isLaterThan(timeToCheck, fromPoint);
+
+        assertTrue(isAfter);
+    }
+
+    @Test
+    public void return_false_if_timestamp_is_not_after_another_one() {
+        final Timestamp fromPoint = getCurrentTime();
+        final Timestamp timeToCheck = subtract(fromPoint, TEN_SECONDS);
+
+        final boolean isAfter = isLaterThan(timeToCheck, fromPoint);
+
+        assertFalse(isAfter);
+    }
+
+    @Test
+    public void compare_timestamps_return_negative_int_if_first_less_than_second_one() {
+        final Timestamp time1 = getCurrentTime();
+        final Timestamp time2 = add(time1, TEN_SECONDS);
+
+        final int result = Timestamps.comparator()
+                                     .compare(time1, time2);
+
+        assertTrue(result < 0);
+    }
+
+    @Test
+    public void compare_two_timestamps_using_comparator_return_zero_if_timestamps_are_equal() {
+        final int secs = 256;
+        final int nanos = 512;
+        final Timestamp time1 = Timestamp.newBuilder()
+                                         .setSeconds(secs)
+                                         .setNanos(nanos)
+                                         .build();
+        final Timestamp time2 = Timestamp.newBuilder()
+                                         .setSeconds(secs)
+                                         .setNanos(nanos)
+                                         .build();
+
+        final int result = Timestamps.comparator()
+                                     .compare(time1, time2);
+
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void compare_timestamps_return_positive_int_if_first_greater_than_second_one() {
+        final Timestamp currentTime = getCurrentTime();
+        final Timestamp timeAfterCurrent = add(currentTime, TEN_SECONDS);
+
+        final int result = Timestamps.comparator()
+                                     .compare(timeAfterCurrent, currentTime);
+
+        assertTrue(result > 0);
+    }
+
+    @Test
+    public void convert_timestamp_to_date_to_nearest_second() {
+
+        final Timestamp expectedTime = getCurrentTime();
+
+        final Date actualDate = toDate(expectedTime);
+        final long actualSeconds = actualDate.getTime() / MILLIS_PER_SECOND;
+
+        assertEquals(expectedTime.getSeconds(), actualSeconds);
+    }
+
+    @Test
+    public void convert_timestamp_to_nanos() {
+        final Timestamp expectedTime = getCurrentTime();
+
+        final long nanos = toNanos(expectedTime);
+        final long expectedNanos = expectedTime.getSeconds() * NANOS_PER_SECOND +
+                                   expectedTime.getNanos();
+
+        assertEquals(expectedNanos, nanos);
+    }
+
+    @Test
+    public void accept_time_provider() {
+        final Timestamp fiveMinutesAgo = subtract(getCurrentTime(),
+                                                  fromMinutes(5));
+
+        setProvider(new TimeTests.FrozenMadHatterParty(fiveMinutesAgo));
+
+        assertEquals(fiveMinutesAgo, getCurrentTime());
+    }
+
+    @Test
+    public void reset_time_provider_to_default() {
+        final Timestamp aMinuteAgo = subtract(
+                systemTime(),
+                fromMinutes(1));
+
+        setProvider(new TimeTests.FrozenMadHatterParty(aMinuteAgo));
+        resetProvider();
+
+        assertNotEquals(aMinuteAgo, getCurrentTime());
+    }
+
+    @Test
+    public void obtain_system_time_millis() {
+        assertNotEquals(0, systemTime());
+    }
+}

--- a/time/src/test/java/io/spine/time/Timestamps2Should.java
+++ b/time/src/test/java/io/spine/time/Timestamps2Should.java
@@ -95,6 +95,16 @@ public class Timestamps2Should {
     }
 
     @Test
+    public void calculate_timestamp_of_moment_in_the_future() {
+        final Timestamp currentTime = getCurrentTime();
+        final Timestamp expected = add(currentTime, TEN_SECONDS);
+
+        final Timestamp actual = TimeTests.Future.secondsFromNow(TEN_SECONDS.getSeconds());
+
+        assertEquals(expected.getSeconds(), actual.getSeconds());
+    }
+
+    @Test
     public void compare_two_timestamps_return_negative_int_if_first_less_than_second_one() {
         final Timestamp time1 = getCurrentTime();
         final Timestamp time2 = add(time1, TEN_SECONDS);

--- a/time/src/test/java/io/spine/time/string/AbstractStringifierTest.java
+++ b/time/src/test/java/io/spine/time/string/AbstractStringifierTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.time.string;
+
+import io.spine.string.Stringifier;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The abstract base for stringifier tests.
+ *
+ * @author Alexander Yevsyukov
+ * @param <T> the type of stringifier objects
+ */
+public abstract class AbstractStringifierTest<T> {
+
+    private final Stringifier<T> stringifier;
+
+    protected AbstractStringifierTest(Stringifier<T> stringifier) {
+        this.stringifier = stringifier;
+    }
+
+    protected abstract T createObject();
+
+    protected Stringifier<T> getStringifier() {
+        return stringifier;
+    }
+
+    @Test
+    public void convert() {
+        T obj = createObject();
+
+        final String str = stringifier.convert(obj);
+        final T convertedBack = stringifier.reverse()
+                                           .convert(str);
+
+        assertEquals(obj, convertedBack);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throw_IAE_on_empty_string() {
+        stringifier.reverse()
+                   .convert("");
+    }
+}

--- a/time/src/test/java/io/spine/time/string/DurationStringifierShould.java
+++ b/time/src/test/java/io/spine/time/string/DurationStringifierShould.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.time.string;
+
+import com.google.protobuf.Duration;
+import io.spine.string.Stringifier;
+import io.spine.time.Durations2;
+import io.spine.time.string.TimeStringifiers;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public class DurationStringifierShould extends AbstractStringifierTest<Duration> {
+
+    public DurationStringifierShould() {
+        super(TimeStringifiers.forDuration());
+    }
+
+    @Override
+    protected Duration createObject() {
+        return Durations2.hoursAndMinutes(5, 37);
+    }
+
+    @Test
+    public void convert_negative_duration() {
+        final Stringifier<Duration> stringifier = getStringifier();
+        final Duration negative = Durations2.hoursAndMinutes(-4, -31);
+        assertEquals(negative, stringifier.reverse()
+                                          .convert(stringifier.convert(negative)));
+    }
+}

--- a/time/src/test/java/io/spine/time/string/LocalDateStringifierShould.java
+++ b/time/src/test/java/io/spine/time/string/LocalDateStringifierShould.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.time.string;
+
+import io.spine.time.LocalDate;
+import io.spine.time.LocalDates;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public class LocalDateStringifierShould extends AbstractStringifierTest<LocalDate> {
+
+    public LocalDateStringifierShould() {
+        super(TimeStringifiers.forLocalDate());
+    }
+
+    @Override
+    protected LocalDate createObject() {
+        return LocalDates.now();
+    }
+}

--- a/time/src/test/java/io/spine/time/string/LocalTimeStringifierShould.java
+++ b/time/src/test/java/io/spine/time/string/LocalTimeStringifierShould.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.time.string;
+
+import io.spine.time.LocalTime;
+import io.spine.time.LocalTimes;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public class LocalTimeStringifierShould extends AbstractStringifierTest<LocalTime> {
+
+    public LocalTimeStringifierShould() {
+        super(TimeStringifiers.forLocalTime());
+    }
+
+    @Override
+    protected LocalTime createObject() {
+        return LocalTimes.now();
+    }
+}

--- a/time/src/test/java/io/spine/time/string/TimeStringifiersShould.java
+++ b/time/src/test/java/io/spine/time/string/TimeStringifiersShould.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.time.string;
+
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import io.spine.string.Stringifier;
+import io.spine.string.StringifierRegistry;
+import io.spine.test.Tests;
+import io.spine.time.LocalDate;
+import io.spine.time.LocalTime;
+import io.spine.time.OffsetDateTime;
+import io.spine.time.OffsetTime;
+import io.spine.time.ZoneOffset;
+import org.junit.Test;
+
+import static io.spine.time.string.TimeStringifiers.forDuration;
+import static io.spine.time.string.TimeStringifiers.forLocalDate;
+import static io.spine.time.string.TimeStringifiers.forLocalTime;
+import static io.spine.time.string.TimeStringifiers.forOffsetDateTime;
+import static io.spine.time.string.TimeStringifiers.forOffsetTime;
+import static io.spine.time.string.TimeStringifiers.forTimestamp;
+import static io.spine.time.string.TimeStringifiers.forZoneOffset;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public class TimeStringifiersShould {
+
+    @Test
+    public void have_utility_ctor() {
+        Tests.assertHasPrivateParameterlessCtor(TimeStringifiers.class);
+    }
+
+    private static Stringifier<Object> getStringifier(Class<?> cls) {
+        return StringifierRegistry.getInstance().get(cls).get();
+    }
+
+    @Test
+    public void register_stringifiers() {
+        assertEquals(forZoneOffset(), getStringifier(ZoneOffset.class));
+        assertEquals(forDuration(), getStringifier(Duration.class));
+        assertEquals(forTimestamp(), getStringifier(Timestamp.class));
+        assertEquals(forLocalDate(), getStringifier(LocalDate.class));
+        assertEquals(forLocalTime(), getStringifier(LocalTime.class));
+        assertEquals(forOffsetDateTime(), getStringifier(OffsetDateTime.class));
+        assertEquals(forOffsetTime(), getStringifier(OffsetTime.class));
+    }
+}

--- a/time/src/test/java/io/spine/time/string/TimestampStringifierShould.java
+++ b/time/src/test/java/io/spine/time/string/TimestampStringifierShould.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.time.string;
+
+import com.google.protobuf.Timestamp;
+import io.spine.string.Stringifiers;
+import org.junit.Test;
+
+import static io.spine.time.Time.getCurrentTime;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public class TimestampStringifierShould extends AbstractStringifierTest<Timestamp> {
+
+    public TimestampStringifierShould() {
+        super(TimeStringifiers.forTimestamp());
+    }
+
+    @Override
+    protected Timestamp createObject() {
+        return getCurrentTime();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throw_exception_when_try_to_convert_inappropriate_string_to_timestamp() {
+        // This uses TextFormat printing, for the output won't be parsable.
+        final String time = getCurrentTime().toString();
+        Stringifiers.fromString(time, Timestamp.class);
+    }
+}

--- a/time/src/test/java/io/spine/time/string/WebSafeTimestampStringifierShould.java
+++ b/time/src/test/java/io/spine/time/string/WebSafeTimestampStringifierShould.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.time.string;
+
+import com.google.protobuf.Timestamp;
+import io.spine.string.Stringifier;
+import org.junit.Test;
+
+import static io.spine.time.Time.getCurrentTime;
+import static io.spine.time.string.TimeStringifiers.forTimestampWebSafe;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public class WebSafeTimestampStringifierShould {
+
+    @Test
+    public void convert_back_and_forth() {
+        final Timestamp timestamp = getCurrentTime();
+        final Stringifier<Timestamp> stringifier = forTimestampWebSafe();
+
+        final String str = stringifier.convert(timestamp);
+        assertEquals(timestamp, stringifier.reverse()
+                                           .convert(str));
+    }
+}

--- a/time/src/test/java/io/spine/time/string/ZoneOffsetStringifierShould.java
+++ b/time/src/test/java/io/spine/time/string/ZoneOffsetStringifierShould.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.time.string;
+
+import io.spine.string.Stringifier;
+import io.spine.time.ZoneOffset;
+import io.spine.time.ZoneOffsets;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public class ZoneOffsetStringifierShould extends AbstractStringifierTest<ZoneOffset> {
+
+    public ZoneOffsetStringifierShould() {
+        super(TimeStringifiers.forZoneOffset());
+    }
+
+    @Override
+    protected ZoneOffset createObject() {
+        return ZoneOffsets.ofHoursMinutes(7, 40);
+    }
+
+    @Test
+    public void convert_negative_zone_offset() {
+        final Stringifier<ZoneOffset> stringifier = getStringifier();
+        final ZoneOffset negative = ZoneOffsets.ofHoursMinutes(-3, -45);
+
+        assertEquals(negative, stringifier.reverse()
+                                          .convert(stringifier.convert(negative)));
+    }
+}


### PR DESCRIPTION
Some of the tests were left behind during relocation of `time` to a new repository.

This PR reverts the removed tests and additionally creates a new `testutil-time` module. 
This module holds the utility test services that no-longer belong to `testutil-base`.