### PR TITLE
Add changes

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -20,7 +20,7 @@
 
 ext {
     // The version of the Spine Base module to be used in this project.
-    spineBaseVersion = '0.10.43-SNAPSHOT'
+    spineBaseVersion = '0.10.45-SNAPSHOT'
 
     // Publish this library with the same version number as Base.
     versionToPublish = spineBaseVersion

--- a/testutil-time/src/main/java/io/spine/time/testing/TimeTests.java
+++ b/testutil-time/src/main/java/io/spine/time/testing/TimeTests.java
@@ -56,7 +56,7 @@ public class TimeTests {
      * @return a seconds value
      */
     public static long currentTimeSeconds() {
-        final long secs = getCurrentTime().getSeconds();
+        long secs = getCurrentTime().getSeconds();
         return secs;
     }
 
@@ -81,6 +81,7 @@ public class TimeTests {
      * sensitive to bounds of minutes, hours, days, etc.
      */
     public static class FrozenMadHatterParty implements Time.Provider {
+
         private final Timestamp frozenTime;
 
         public FrozenMadHatterParty(Timestamp frozenTime) {
@@ -126,7 +127,7 @@ public class TimeTests {
         @CanIgnoreReturnValue
         public synchronized Timestamp forward(long hoursDelta) {
             checkPositive(hoursDelta);
-            final Timestamp newTime = add(this.currentTime, hours(hoursDelta));
+            Timestamp newTime = add(this.currentTime, hours(hoursDelta));
             setCurrentTime(newTime);
             return newTime;
         }
@@ -138,7 +139,7 @@ public class TimeTests {
         @CanIgnoreReturnValue
         public synchronized Timestamp backward(long hoursDelta) {
             checkPositive(hoursDelta);
-            final Timestamp newTime = subtract(this.currentTime, hours(hoursDelta));
+            Timestamp newTime = subtract(this.currentTime, hours(hoursDelta));
             setCurrentTime(newTime);
             return newTime;
         }
@@ -149,8 +150,8 @@ public class TimeTests {
      */
     public static class Past {
 
+        /** Prevents instantiation of this utility class. */
         private Past() {
-            // Do not allow creating instances of this utility class.
         }
 
         /**
@@ -162,8 +163,8 @@ public class TimeTests {
          */
         public static Timestamp minutesAgo(int value) {
             checkPositive(value);
-            final Timestamp currentTime = getCurrentTime();
-            final Timestamp result = subtract(currentTime, Durations2.fromMinutes(value));
+            Timestamp currentTime = getCurrentTime();
+            Timestamp result = subtract(currentTime, Durations2.fromMinutes(value));
             return result;
         }
 
@@ -175,8 +176,8 @@ public class TimeTests {
          */
         public static Timestamp secondsAgo(long value) {
             checkPositive(value);
-            final Timestamp currentTime = getCurrentTime();
-            final Timestamp result = subtract(currentTime, seconds(value));
+            Timestamp currentTime = getCurrentTime();
+            Timestamp result = subtract(currentTime, seconds(value));
             return result;
         }
     }
@@ -186,8 +187,8 @@ public class TimeTests {
      */
     public static class Future {
 
+        /** Prevents instantiation of this utility class. */        
         private Future() {
-            // Do not allow creating instances of this utility class.
         }
 
         /**
@@ -198,8 +199,8 @@ public class TimeTests {
          */
         public static Timestamp secondsFromNow(long seconds) {
             checkPositive(seconds);
-            final Timestamp currentTime = getCurrentTime();
-            final Timestamp result = add(currentTime, fromSeconds(seconds));
+            Timestamp currentTime = getCurrentTime();
+            Timestamp result = add(currentTime, fromSeconds(seconds));
             return result;
         }
 
@@ -210,13 +211,13 @@ public class TimeTests {
         public static boolean isFuture(Timestamp timestamp) {
             // Do not use `getCurrentTime()` as we may use custom `TimestampProvider` already.
             // Get time from metal.
-            final Timestamp currentSystemTime = systemTime();
+            Timestamp currentSystemTime = systemTime();
 
             // NOTE: we have the risk of having these two timestamps too close to each other
             // so that the passed timestamp becomes "the past" around the time of this call.
             // To avoid this, select some time in the "distant" future.
-            final boolean result = Timestamps.comparator()
-                                             .compare(currentSystemTime, timestamp) < 0;
+            boolean result = Timestamps.comparator()
+                                       .compare(currentSystemTime, timestamp) < 0;
             return result;
         }
     }

--- a/time/src/main/java/io/spine/time/Constants.java
+++ b/time/src/main/java/io/spine/time/Constants.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
  * @author Mykhailo Drachuk
  */
 @SuppressWarnings("NumericCastThatLosesPrecision")
-class Constants {
+final class Constants {
 
     /** The count of nanoseconds in one second. */
     static final int NANOS_PER_SECOND = (int) TimeUnit.SECONDS.toNanos(1);

--- a/time/src/main/java/io/spine/time/DaysOfWeek.java
+++ b/time/src/main/java/io/spine/time/DaysOfWeek.java
@@ -34,7 +34,7 @@ import static java.time.temporal.ChronoField.DAY_OF_WEEK;
  *
  * @author Alexander Yevsyukov
  */
-public class DaysOfWeek {
+public final class DaysOfWeek {
 
     /** Prevents instantiation of this utility class. */
     private DaysOfWeek() {

--- a/time/src/main/java/io/spine/time/DtPreconditions.java
+++ b/time/src/main/java/io/spine/time/DtPreconditions.java
@@ -32,7 +32,7 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  *
  * @author Alexander Yevsyukov
  */
-class DtPreconditions {
+final class DtPreconditions {
 
     /** Prevent instantiation of this utility class. */
     private DtPreconditions() {

--- a/time/src/main/java/io/spine/time/LocalDateTimes.java
+++ b/time/src/main/java/io/spine/time/LocalDateTimes.java
@@ -32,7 +32,7 @@ import static io.spine.time.LocalTimes.checkTime;
  *
  * @author Alexander Yevsyukov
  */
-public class LocalDateTimes {
+public final class LocalDateTimes {
 
     /** Prevents instantiation of this utility class. */
     private LocalDateTimes() {

--- a/time/src/main/java/io/spine/time/Months.java
+++ b/time/src/main/java/io/spine/time/Months.java
@@ -35,7 +35,7 @@ import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
  * @author Mykhailo Drachuk
  * @author Alexander Yevsyukov
  */
-public class Months {
+public final class Months {
 
     /** Prevent instantiation of this utility class. */
     private Months() {

--- a/time/src/main/java/io/spine/time/TimeChanges.java
+++ b/time/src/main/java/io/spine/time/TimeChanges.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.time;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Utility class for working with date-time changes.
+ *
+ * @author Alexander Yevsyukov
+ */
+public class TimeChanges {
+
+    /** Prevents instantiation of this utility class. */
+    private TimeChanges() {
+    }
+
+    /**
+     * Creates {@link LocalDateChange} object for the passed previous and new field values of
+     * local date.
+     *
+     * <p>Passed values cannot be equal.
+     */
+    public static LocalDateChange of(LocalDate previousValue, LocalDate newValue) {
+        checkNotEqual(previousValue, newValue);
+
+        LocalDateChange result = LocalDateChange
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .build();
+        return result;
+    }
+
+    /**
+     * Creates {@link LocalTimeChange} object for the passed previous and new field values of
+     * local time.
+     *
+     * <p>Passed values cannot be equal.
+     */
+    public static LocalTimeChange of(LocalTime previousValue, LocalTime newValue) {
+        checkNotEqual(previousValue, newValue);
+
+        LocalTimeChange result = LocalTimeChange
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .build();
+        return result;
+    }
+
+    /**
+     * Creates {@link OffsetTimeChange} object for the passed previous and new field values of
+     * offset time.
+     *
+     * <p>Passed values cannot be equal.
+     */
+    public static OffsetTimeChange of(OffsetTime previousValue, OffsetTime newValue) {
+        checkNotEqual(previousValue, newValue);
+
+        OffsetTimeChange result = OffsetTimeChange
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .build();
+        return result;
+    }
+
+    /**
+     * Creates {@link OffsetDateTimeChange} object for the passed previous and new field values of
+     * offset time.
+     *
+     * <p>Passed values cannot be equal.
+     */
+    public static OffsetDateTimeChange of(OffsetDateTime previousValue, OffsetDateTime newValue) {
+        checkNotEqual(previousValue, newValue);
+
+        OffsetDateTimeChange result = OffsetDateTimeChange
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .build();
+        return result;
+    }
+
+    /**
+     * Ensures that parameters are not equal.
+     *
+     * @throws IllegalArgumentException in case if values are equal
+     */
+    private static <T> void checkNotEqual(T previousValue, T newValue) {
+        checkNotNull(previousValue);
+        checkNotNull(newValue);
+        checkArgument(!newValue.equals(previousValue),
+                      "newValue cannot be equal to previousValue");
+    }
+}

--- a/time/src/main/java/io/spine/time/YearMonths.java
+++ b/time/src/main/java/io/spine/time/YearMonths.java
@@ -31,7 +31,7 @@ import static io.spine.time.DtPreconditions.checkNotDefault;
  *
  * @author Alexander Yevsyukov
  */
-public class YearMonths {
+public final class YearMonths {
 
     /** Prevents instantiation of this utility class. */
     private YearMonths() {

--- a/time/src/main/java/io/spine/time/ZoneIds.java
+++ b/time/src/main/java/io/spine/time/ZoneIds.java
@@ -30,7 +30,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author Alexander Yevsyukov
  */
-public class ZoneIds {
+public final class ZoneIds {
 
     /** Prevents instantiation of this utility class. */
     private ZoneIds() {

--- a/time/src/main/java/io/spine/time/ZonedDateTimes.java
+++ b/time/src/main/java/io/spine/time/ZonedDateTimes.java
@@ -31,7 +31,7 @@ import static io.spine.time.DtPreconditions.checkNotDefault;
  *
  * @author Alexander Yevsyukov
  */
-public class ZonedDateTimes {
+public final class ZonedDateTimes {
 
     /** Prevents instantiation of this utility class. */
     private ZonedDateTimes() {

--- a/time/src/main/proto/spine/time/time_change.proto
+++ b/time/src/main/proto/spine/time/time_change.proto
@@ -1,0 +1,86 @@
+//
+// Copyright 2018, TeamDev. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.time;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_multiple_files = true;
+option java_outer_classname = "TimeChangeProto";
+option java_package = "io.spine.time";
+
+import "spine/time/time.proto";
+
+//
+// This file provides messages that define changes of date-time fields of the types defined 
+// by the Spine Time library.
+//
+// For change types for non-date/time values and for the `TimestampChange` message definition 
+// please see `spine/change/change.proto`.
+//
+// Messages defined in this file follow the conventions defined by the `change.proto`.
+//
+
+//
+// Changes of date/time values.
+//--------------------------------
+
+// Definition of a change of `LocalDate` fields.
+message LocalDateChange {
+
+    // The value of fields that are changing.
+    LocalDate previous_value = 1;
+
+    // The new value of fields.
+    LocalDate new_value = 2;
+}
+
+// Definition of a change of `LocalTime` fields.
+message LocalTimeChange {
+
+    // The value of fields that are changing.
+    LocalTime previous_value = 1;
+
+    // The new value of fields.
+    LocalTime new_value = 2;
+}
+
+// Definition of a change of `OffsetTime` fields.
+message OffsetTimeChange {
+
+    // The value of fields that are changing.
+    OffsetTime previous_value = 1;
+
+    // The new value of fields.
+    OffsetTime new_value = 2;
+}
+
+// Definition of a change of `OffsetDateTime` fields.
+message OffsetDateTimeChange {
+
+    // The value of fields that are changing.
+    OffsetDateTime previous_value = 1;
+
+    // The new value of fields.
+    OffsetDateTime new_value = 2;
+}
+

--- a/time/src/main/proto/spine/time/time_change.proto
+++ b/time/src/main/proto/spine/time/time_change.proto
@@ -47,40 +47,40 @@ import "spine/time/time.proto";
 // Definition of a change of `LocalDate` fields.
 message LocalDateChange {
 
-    // The value of fields that are changing.
+    // The value of the field that are changing.
     LocalDate previous_value = 1;
 
-    // The new value of fields.
+    // The new value of the field.
     LocalDate new_value = 2;
 }
 
 // Definition of a change of `LocalTime` fields.
 message LocalTimeChange {
 
-    // The value of fields that are changing.
+    // The value of the field that are changing.
     LocalTime previous_value = 1;
 
-    // The new value of fields.
+    // The new value of the field.
     LocalTime new_value = 2;
 }
 
 // Definition of a change of `OffsetTime` fields.
 message OffsetTimeChange {
 
-    // The value of fields that are changing.
+    // The value of the field that are changing.
     OffsetTime previous_value = 1;
 
-    // The new value of fields.
+    // The new value of the field.
     OffsetTime new_value = 2;
 }
 
 // Definition of a change of `OffsetDateTime` fields.
 message OffsetDateTimeChange {
 
-    // The value of fields that are changing.
+    // The value of the field that are changing.
     OffsetDateTime previous_value = 1;
 
-    // The new value of fields.
+    // The new value of the field.
     OffsetDateTime new_value = 2;
 }
 

--- a/time/src/test/java/io/spine/time/TimeChangesTest.java
+++ b/time/src/test/java/io/spine/time/TimeChangesTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.time;
+
+import com.google.common.testing.NullPointerTester;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TimeChangesTest {
+
+    @Test
+    void utilityCtor() {
+        assertHasPrivateParameterlessCtor(TimeChanges.class);
+    }
+
+    @Test
+    void nullCheck() {
+        ZoneOffset utc = ZoneOffsets.utc();
+        new NullPointerTester()
+                .setDefault(OffsetTime.class, OffsetTimes.now(utc))
+                .setDefault(OffsetDateTime.class, OffsetDateTimes.now(utc))
+                .setDefault(LocalDate.class, LocalDates.now())
+                .setDefault(LocalTime.class, LocalTimes.now())
+                .testAllPublicStaticMethods(TimeChanges.class);
+    }
+
+    @Nested
+    @DisplayName("fail to create a change for equal values")
+    class RejectEqual {
+
+        @Test
+        @DisplayName("LocalDate")
+        void localDates() {
+            final LocalDate today = LocalDates.now();
+            assertThrows(IllegalArgumentException.class, () -> TimeChanges.of(today, today));
+        }
+
+        @Test
+        @DisplayName("LocalTime")
+        void localTimes() {
+            final LocalTime now = LocalTimes.now();
+            assertThrows(IllegalArgumentException.class, () -> TimeChanges.of(now, now));
+        }
+
+        @Test
+        @DisplayName("OffsetTime")
+        void offsetTimes() {
+            final ZoneOffset inLuxembourg = ZoneOffsets.ofHours(1);
+            final OffsetTime now = OffsetTimes.now(inLuxembourg);
+            assertThrows(IllegalArgumentException.class, () -> TimeChanges.of(now, now));
+        }
+
+        @Test
+        @DisplayName("OffsetDateTime")
+        void offsetDateTimes() {
+            final ZoneOffset inLuxembourg = ZoneOffsets.ofHours(1);
+            final OffsetDateTime now = OffsetDateTimes.now(inLuxembourg);
+            assertThrows(IllegalArgumentException.class, () -> TimeChanges.of(now, now));
+        }
+    }
+
+    @Nested
+    @DisplayName("create a value of type")
+    class Create {
+        @Test
+        @DisplayName("LocalDate")
+        void forLocalDates() {
+            final LocalDate today = LocalDates.now();
+            final LocalDate tomorrow = LocalDates.of(LocalDates.toJavaTime(today).plusDays(1));
+
+            final LocalDateChange result = TimeChanges.of(today, tomorrow);
+
+            assertEquals(today, result.getPreviousValue());
+            assertEquals(tomorrow, result.getNewValue());
+        }
+
+        @Test
+        @DisplayName("LocalTime")
+        void forLocalTimes() {
+            final LocalTime now = LocalTimes.now();
+            final LocalTime inFiveHours = LocalTimes.of(LocalTimes.toJavaTime(now)
+                                                                  .plusHours(5));
+
+            final LocalTimeChange result = TimeChanges.of(now, inFiveHours);
+
+            assertEquals(now, result.getPreviousValue());
+            assertEquals(inFiveHours, result.getNewValue());
+        }
+
+        @Test
+        @DisplayName("OffsetTime")
+        void forOffsetTimes() {
+            final ZoneOffset inKiev = ZoneOffsets.ofHours(3);
+            final ZoneOffset inLuxembourg = ZoneOffsets.ofHours(1);
+            final OffsetTime previousTime = OffsetTimes.now(inKiev);
+            final OffsetTime newTime = OffsetTimes.now(inLuxembourg);
+
+            final OffsetTimeChange result = TimeChanges.of(previousTime, newTime);
+
+            assertEquals(previousTime, result.getPreviousValue());
+            assertEquals(newTime, result.getNewValue());
+        }
+
+        @Test
+        @DisplayName("OffsetDateTime")
+        void forOffsetDateTimes() {
+            final ZoneOffset inKiev = ZoneOffsets.ofHours(3);
+            final ZoneOffset inLuxembourg = ZoneOffsets.ofHours(1);
+            final OffsetDateTime previousDateTime = OffsetDateTimes.now(inKiev);
+            final OffsetDateTime newDateTime = OffsetDateTimes.now(inLuxembourg);
+
+            final OffsetDateTimeChange result = TimeChanges.of(previousDateTime, newDateTime);
+
+            assertEquals(previousDateTime, result.getPreviousValue());
+            assertEquals(newDateTime, result.getNewValue());
+        }
+    }
+}

--- a/time/src/test/java/io/spine/time/TimeChangesTest.java
+++ b/time/src/test/java/io/spine/time/TimeChangesTest.java
@@ -21,6 +21,7 @@
 package io.spine.time;
 
 import com.google.common.testing.NullPointerTester;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -57,30 +58,30 @@ class TimeChangesTest {
         @Test
         @DisplayName("LocalDate")
         void localDates() {
-            final LocalDate today = LocalDates.now();
+            LocalDate today = LocalDates.now();
             assertThrows(IllegalArgumentException.class, () -> TimeChanges.of(today, today));
         }
 
         @Test
         @DisplayName("LocalTime")
         void localTimes() {
-            final LocalTime now = LocalTimes.now();
+            LocalTime now = LocalTimes.now();
             assertThrows(IllegalArgumentException.class, () -> TimeChanges.of(now, now));
         }
 
         @Test
         @DisplayName("OffsetTime")
         void offsetTimes() {
-            final ZoneOffset inLuxembourg = ZoneOffsets.ofHours(1);
-            final OffsetTime now = OffsetTimes.now(inLuxembourg);
+            ZoneOffset inLuxembourg = ZoneOffsets.ofHours(1);
+            OffsetTime now = OffsetTimes.now(inLuxembourg);
             assertThrows(IllegalArgumentException.class, () -> TimeChanges.of(now, now));
         }
 
         @Test
         @DisplayName("OffsetDateTime")
         void offsetDateTimes() {
-            final ZoneOffset inLuxembourg = ZoneOffsets.ofHours(1);
-            final OffsetDateTime now = OffsetDateTimes.now(inLuxembourg);
+            ZoneOffset inLuxembourg = ZoneOffsets.ofHours(1);
+            OffsetDateTime now = OffsetDateTimes.now(inLuxembourg);
             assertThrows(IllegalArgumentException.class, () -> TimeChanges.of(now, now));
         }
     }
@@ -88,13 +89,27 @@ class TimeChangesTest {
     @Nested
     @DisplayName("create a value of type")
     class Create {
+
+        private LocalTime now;
+        private ZoneOffset inKiev;
+        private ZoneOffset inLuxembourg;
+
+        @BeforeEach
+        void setUp() {
+            now = LocalTimes.now();
+            // Assume it's Summer now.
+            inKiev = ZoneOffsets.ofHours(3);
+            inLuxembourg = ZoneOffsets.ofHours(2);
+        }
+
         @Test
         @DisplayName("LocalDate")
         void forLocalDates() {
-            final LocalDate today = LocalDates.now();
-            final LocalDate tomorrow = LocalDates.of(LocalDates.toJavaTime(today).plusDays(1));
+            LocalDate today = LocalDates.now();
+            LocalDate tomorrow = LocalDates.of(LocalDates.toJavaTime(today)
+                                                         .plusDays(1));
 
-            final LocalDateChange result = TimeChanges.of(today, tomorrow);
+            LocalDateChange result = TimeChanges.of(today, tomorrow);
 
             assertEquals(today, result.getPreviousValue());
             assertEquals(tomorrow, result.getNewValue());
@@ -103,11 +118,10 @@ class TimeChangesTest {
         @Test
         @DisplayName("LocalTime")
         void forLocalTimes() {
-            final LocalTime now = LocalTimes.now();
-            final LocalTime inFiveHours = LocalTimes.of(LocalTimes.toJavaTime(now)
-                                                                  .plusHours(5));
+            LocalTime inFiveHours = LocalTimes.of(LocalTimes.toJavaTime(now)
+                                                            .plusHours(5));
 
-            final LocalTimeChange result = TimeChanges.of(now, inFiveHours);
+            LocalTimeChange result = TimeChanges.of(now, inFiveHours);
 
             assertEquals(now, result.getPreviousValue());
             assertEquals(inFiveHours, result.getNewValue());
@@ -116,12 +130,10 @@ class TimeChangesTest {
         @Test
         @DisplayName("OffsetTime")
         void forOffsetTimes() {
-            final ZoneOffset inKiev = ZoneOffsets.ofHours(3);
-            final ZoneOffset inLuxembourg = ZoneOffsets.ofHours(1);
-            final OffsetTime previousTime = OffsetTimes.now(inKiev);
-            final OffsetTime newTime = OffsetTimes.now(inLuxembourg);
+            OffsetTime previousTime = OffsetTimes.now(inKiev);
+            OffsetTime newTime = OffsetTimes.now(inLuxembourg);
 
-            final OffsetTimeChange result = TimeChanges.of(previousTime, newTime);
+            OffsetTimeChange result = TimeChanges.of(previousTime, newTime);
 
             assertEquals(previousTime, result.getPreviousValue());
             assertEquals(newTime, result.getNewValue());
@@ -130,12 +142,10 @@ class TimeChangesTest {
         @Test
         @DisplayName("OffsetDateTime")
         void forOffsetDateTimes() {
-            final ZoneOffset inKiev = ZoneOffsets.ofHours(3);
-            final ZoneOffset inLuxembourg = ZoneOffsets.ofHours(1);
-            final OffsetDateTime previousDateTime = OffsetDateTimes.now(inKiev);
-            final OffsetDateTime newDateTime = OffsetDateTimes.now(inLuxembourg);
+            OffsetDateTime previousDateTime = OffsetDateTimes.now(inKiev);
+            OffsetDateTime newDateTime = OffsetDateTimes.now(inLuxembourg);
 
-            final OffsetDateTimeChange result = TimeChanges.of(previousDateTime, newDateTime);
+            OffsetDateTimeChange result = TimeChanges.of(previousDateTime, newDateTime);
 
             assertEquals(previousDateTime, result.getPreviousValue());
             assertEquals(newDateTime, result.getNewValue());

--- a/time/src/test/java/io/spine/time/TimeChangesTest.java
+++ b/time/src/test/java/io/spine/time/TimeChangesTest.java
@@ -29,6 +29,9 @@ import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+/**
+ * @author Alexander Yevsyukov
+ */
 class TimeChangesTest {
 
     @Test


### PR DESCRIPTION
This PR adds definition of date-time based changes moved into the library from `core-java`.

It's an interim change. We're going to have a common `Change` object with two `Any` inside. That's why this PR does not have  the change types for all the types introduced by this library.
