### PR TITLE
Allow local time midnight

### DIFF
--- a/time/src/main/proto/spine/time/time.proto
+++ b/time/src/main/proto/spine/time/time.proto
@@ -85,9 +85,17 @@ message LocalDate {
 //
 // It is a description of a time, not an instant on a time-line.
 message LocalTime {
-    int32 hour = 1 [(required) = true];
-    int32 minute = 2 [(required) = true];
+
+    // An hour from 0 to 23.
+    int32 hour = 1;
+
+    // Minutes of an hour from 0 to 59.
+    int32 minute = 2;
+
+    // Seconds of a minute, specified from 0 to 59.
     int32 second = 3;
+
+    // Fractions of a second from 0 to 999,999,999.
     int32 nano = 4;
 }
 

--- a/time/src/main/proto/spine/time/time.proto
+++ b/time/src/main/proto/spine/time/time.proto
@@ -53,7 +53,11 @@ enum Month {
 // The purpose of this type is to store values like "June 2018".
 //
 message YearMonth {
+
+    // A year with `1` being year 1 CE and `-1` being 1 BC.
     int32 year = 1 [(required) = true];
+
+    // One of 12 Gregorian calendar months specified by `Month`.
     Month month = 2 [(required) = true];
 }
 
@@ -76,8 +80,14 @@ enum DayOfWeek {
 //
 // Use this message for describing a date (e.g. a birthday).
 message LocalDate {
+
+    // A year with `1` being year 1 CE and `-1` being 1 BC. 
     int32 year = 1 [(required) = true];
+
+    // One of 12 Gregorian calendar months specified by `Month`.
     Month month = 2 [(required) = true];
+
+    // A day which must be from 1 to 31 and valid for the year and month.
     int32 day = 3 [(required) = true];
 }
 

--- a/time/src/test/java/io/spine/time/LocalTimesTest.java
+++ b/time/src/test/java/io/spine/time/LocalTimesTest.java
@@ -214,4 +214,18 @@ class LocalTimesTest extends AbstractDateTimeUtilityTest<LocalTime, java.time.Lo
         assertEquals(LocalTime.getDefaultInstance(), LocalTimes.parse("00:00"));
         assertEquals(LocalTime.getDefaultInstance(), LocalTimes.parse("00:00:00"));
     }
+
+    @Test
+    @DisplayName("builds a midnight date")
+    void buildMidnight() {
+        LocalTime time = LocalTimeVBuilder
+                .newBuilder()
+                .setHour(0)
+                .setMinute(0)
+                .setSecond(0)
+                .build();
+        assertEquals(0, time.getHour());
+        assertEquals(0, time.getMinute());
+        assertEquals(0, time.getSecond());
+    }
 }


### PR DESCRIPTION
This PR documents the `year`, `month` and `day` for `LocalDate` and `YearMonth`, and allows building validated `LocalTime` instances with midnight time (`00-00-00`).