### PR TITLE
Update base to 1.0.0-SNAPSHOT

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -20,7 +20,7 @@
 
 ext {
     // The version of the Spine Base module to be used in this project.
-    spineBaseVersion = '1.0.0-pre2'
+    spineBaseVersion = '1.0.0-SNAPSHOT'
 
     // Publish this library with the same version number as Base.
     versionToPublish = spineBaseVersion


### PR DESCRIPTION
In this PR we change the used version of `base` and the version of this library to `1.0.0-SNAPSHOT`.

This is required in order to avoid classpath collisions in the `core` module, which uses both the artifacts.