### PR TITLE
Replace `(required)` with `(min)` and `(max)`

### DIFF
--- a/time/src/main/proto/spine/time/time.proto
+++ b/time/src/main/proto/spine/time/time.proto
@@ -56,7 +56,7 @@ enum Month {
 message YearMonth {
 
     // A year with `1` being year 1 CE and `-1` being 1 BC.
-    int32 year = 1 [(required) = true];
+    int32 year = 1;
 
     // One of 12 Gregorian calendar months specified by `Month`.
     Month month = 2 [(required) = true];
@@ -83,13 +83,13 @@ enum DayOfWeek {
 message LocalDate {
 
     // A year with `1` being year 1 CE and `-1` being 1 BC. 
-    int32 year = 1 [(required) = true];
+    int32 year = 1;
 
     // One of 12 Gregorian calendar months specified by `Month`.
     Month month = 2 [(required) = true];
 
     // A day which must be from 1 to 31 and valid for the year and month.
-    int32 day = 3 [(required) = true];
+    int32 day = 3 [(min).value = "1", (max).value = "31"];
 }
 
 // A time without a time-zone.
@@ -98,16 +98,16 @@ message LocalDate {
 message LocalTime {
 
     // An hour from 0 to 23.
-    int32 hour = 1;
+    int32 hour = 1 [(min).value = "0", (max).value = "23"];
 
     // Minutes of an hour from 0 to 59.
-    int32 minute = 2;
+    int32 minute = 2 [(min).value = "0", (max).value = "59"];
 
     // Seconds of a minute, specified from 0 to 59.
-    int32 second = 3;
+    int32 second = 3 [(min).value = "0", (max).value = "59"];
 
     // Fractions of a second from 0 to 999,999,999.
-    int32 nano = 4;
+    int32 nano = 4 [(min).value = "0", (max).value = "999999999"];
 }
 
 // A date-time without a time-zone.


### PR DESCRIPTION
By now, we've used the `(required)` option for number fields in messages representing time.

In this PR we substitute the `(required)` option for `(min)` and `(max)` options as well as add some more `(min)`/`(max)` option where applicable.