### PR TITLE
Enable PMD static analysis during the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ subprojects {
 
     apply plugin: 'java-library'
     apply plugin: 'net.ltgt.errorprone'
+    apply plugin: 'pmd'
     apply plugin: 'com.google.protobuf'
     apply plugin: 'maven-publish'
 
@@ -248,6 +249,8 @@ subprojects {
             }
         }
     }
+
+    apply from: deps.scripts.pmd
 }
 
 // IDEA project configuration.

--- a/time/src/main/java/io/spine/time/AbstractConverter.java
+++ b/time/src/main/java/io/spine/time/AbstractConverter.java
@@ -37,6 +37,7 @@ abstract class AbstractConverter<T, P> extends Converter<T, P> implements Serial
     private final String identify;
 
     protected AbstractConverter(String identity) {
+        super();
         this.identify = identity;
     }
 

--- a/version.gradle
+++ b/version.gradle
@@ -20,7 +20,7 @@
 
 ext {
     // The version of the Spine Base module to be used in this project.
-    spineBaseVersion = '1.0.0-pre4'
+    spineBaseVersion = '1.0.0-SNAPSHOT'
 
     // Publish this library with the same version number as Base.
     versionToPublish = spineBaseVersion


### PR DESCRIPTION
This PR enables the static code analysis.

See https://github.com/SpineEventEngine/config/pull/43 for more details on PMD rules.

The library version is set to `1.0.0-SNAPSHOT`.