### PR TITLE
Ensure we always use OpenJDK8 to build the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+jdk:
+  - openjdk8
+
 # To increase the memory size available during Travis build.
 sudo: required
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spine Time: Protobuf-based Date/Time types
 
-[![Build Status](https://travis-ci.org/SpineEventEngine/time.svg?branch=master)](https://travis-ci.org/SpineEventEngine/time)
+[![Build Status](https://travis-ci.com/SpineEventEngine/time.svg?branch=master)](https://travis-ci.com/SpineEventEngine/time)
 [![codecov](https://codecov.io/gh/SpineEventEngine/time/branch/master/graph/badge.svg)](https://codecov.io/gh/SpineEventEngine/time)
 [![license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
 


### PR DESCRIPTION
In the PR I have enforced usage of the OpenJDK8 with our Travis CI builds.

As a part of the PR, I have also migrated Travis CI badge to the `travis-ci.com` website.