### PR TITLE
Integrate validation code generation

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -30,12 +30,6 @@
     </XML>
     <codeStyleSettings language="Dart">
       <option name="RIGHT_MARGIN" value="100" />
-      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-      <option name="ALIGN_MULTILINE_PARAMETERS" value="true" />
-      <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
-      <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
-      <option name="WRAP_ON_TYPING" value="0" />
       <indentOptions>
         <option name="INDENT_SIZE" value="4" />
         <option name="TAB_SIZE" value="4" />

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ ext {
 }
 
 allprojects {
-    apply plugin: 'maven'
+    apply plugin: 'base'
     apply plugin: 'jacoco'
     apply plugin: 'idea'
     apply plugin: 'project-report'

--- a/license-report.md
+++ b/license-report.md
@@ -379,7 +379,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jan 02 17:15:36 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 02 17:27:14 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -795,4 +795,4 @@ This report was generated on **Thu Jan 02 17:15:36 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jan 02 17:15:37 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 02 17:27:19 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-testutil-time:1.3.0`
+# Dependencies of `io.spine:spine-testutil-time:1.3.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -379,12 +379,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Dec 12 18:29:39 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 30 16:06:57 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-time:1.3.0`
+# Dependencies of `io.spine:spine-time:1.3.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -444,10 +444,6 @@ This report was generated on **Thu Dec 12 18:29:39 EET 2019** using [Gradle-Lice
 1. **Group:** antlr **Name:** antlr **Version:** 2.7.7
      * **POM Project URL:** [http://www.antlr.org/](http://www.antlr.org/)
      * **POM License: BSD License** - [http://www.antlr.org/license.html](http://www.antlr.org/license.html)
-
-1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
-     * **POM Project URL:** [http://aopalliance.sourceforge.net](http://aopalliance.sourceforge.net)
-     * **POM License: Public Domain**
 
 1. **Group:** com.beust **Name:** jcommander **Version:** 1.72
      * **POM Project URL:** [http://jcommander.org](http://jcommander.org)
@@ -517,7 +513,7 @@ This report was generated on **Thu Dec 12 18:29:39 EET 2019** using [Gradle-Lice
      * **POM Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.gradle **Name:** osdetector-gradle-plugin **Version:** 1.4.0
+1. **Group:** com.google.gradle **Name:** osdetector-gradle-plugin **Version:** 1.6.2
      * **POM Project URL:** [https://github.com/google/osdetector-gradle-plugin](https://github.com/google/osdetector-gradle-plugin)
      * **POM License: Apache License 2.0** - [http://opensource.org/licenses/Apache-2.0](http://opensource.org/licenses/Apache-2.0)
 
@@ -539,7 +535,7 @@ This report was generated on **Thu Dec 12 18:29:39 EET 2019** using [Gradle-Lice
      * **POM Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.protobuf **Name:** protobuf-gradle-plugin **Version:** 0.8.10
+1. **Group:** com.google.protobuf **Name:** protobuf-gradle-plugin **Version:** 0.8.11
      * **POM Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
      * **POM License: BSD 3-Clause** - [http://opensource.org/licenses/BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause)
 
@@ -633,22 +629,11 @@ This report was generated on **Thu Dec 12 18:29:39 EET 2019** using [Gradle-Lice
      * **POM Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
      * **POM License: CDDL + GPLv2 with classpath exception** - [https://github.com/javaee/javax.annotation/blob/master/LICENSE](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
 
-1. **Group:** javax.annotation **Name:** jsr250-api **Version:** 1.0
-     * **POM Project URL:** [http://jcp.org/aboutJava/communityprocess/final/jsr250/index.html](http://jcp.org/aboutJava/communityprocess/final/jsr250/index.html)
-     * **POM License: COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0** - [https://glassfish.dev.java.net/public/CDDLv1.0.html](https://glassfish.dev.java.net/public/CDDLv1.0.html)
-
-1. **Group:** javax.enterprise **Name:** cdi-api **Version:** 1.0
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-1. **Group:** javax.inject **Name:** javax.inject **Version:** 1
-     * **POM Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** junit **Name:** junit **Version:** 4.12
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
-1. **Group:** kr.motd.maven **Name:** os-maven-plugin **Version:** 1.4.0.Final
+1. **Group:** kr.motd.maven **Name:** os-maven-plugin **Version:** 1.6.2
      * **POM Project URL:** [https://github.com/trustin/os-maven-plugin/](https://github.com/trustin/os-maven-plugin/)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -688,15 +673,6 @@ This report was generated on **Thu Dec 12 18:29:39 EET 2019** using [Gradle-Lice
      * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
      * **POM License: Apache License, Version 2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.apache.maven **Name:** maven-artifact **Version:** 3.2.1
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** org.apache.maven **Name:** maven-model **Version:** 3.2.1
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** org.apache.maven **Name:** maven-plugin-api **Version:** 3.2.1
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** org.apiguardian **Name:** apiguardian-api **Version:** 1.0.0
      * **POM Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -724,25 +700,6 @@ This report was generated on **Thu Dec 12 18:29:39 EET 2019** using [Gradle-Lice
 1. **Group:** org.codehaus.mojo **Name:** animal-sniffer-annotations **Version:** 1.18
      * **POM License: MIT license** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** org.codehaus.plexus **Name:** plexus-classworlds **Version:** 2.4
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** org.codehaus.plexus **Name:** plexus-component-annotations **Version:** 1.5.5
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** org.codehaus.plexus **Name:** plexus-utils **Version:** 3.0.17
-     * **POM Project URL:** [http://plexus.codehaus.org/plexus-utils](http://plexus.codehaus.org/plexus-utils)
-     * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1. **Group:** org.eclipse.sisu **Name:** org.eclipse.sisu.inject **Version:** 0.0.0.M5
-     * **Manifest Project URL:** [http://www.eclipse.org/sisu/](http://www.eclipse.org/sisu/)
-     * **POM License: Eclipse Public License, Version 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
-
-1. **Group:** org.eclipse.sisu **Name:** org.eclipse.sisu.plexus **Version:** 0.0.0.M5
-     * **Manifest Project URL:** [http://www.eclipse.org/sisu/](http://www.eclipse.org/sisu/)
-     * **POM License: Eclipse Public License, Version 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
 1. **Group:** org.hamcrest **Name:** hamcrest-all **Version:** 1.3
      * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
@@ -833,13 +790,9 @@ This report was generated on **Thu Dec 12 18:29:39 EET 2019** using [Gradle-Lice
      * **POM Project URL:** [http://pcollections.org](http://pcollections.org)
      * **POM License: The MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-1. **Group:** org.sonatype.sisu **Name:** sisu-guice **Version:** 3.1.0
-     * **Manifest Project URL:** [http://code.google.com/p/google-guice/](http://code.google.com/p/google-guice/)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
     
         
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Dec 12 18:29:45 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 30 16:06:58 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -379,7 +379,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 30 16:06:57 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 02 17:15:36 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -795,4 +795,4 @@ This report was generated on **Mon Dec 30 16:06:57 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 30 16:06:58 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jan 02 17:15:37 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-time</artifactId>
-<version>1.3.0</version>
+<version>1.3.2</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -52,7 +52,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -64,7 +64,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -141,17 +141,17 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-errorprone-checks</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.2</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.2</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.2</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/time/build.gradle
+++ b/time/build.gradle
@@ -38,3 +38,7 @@ dependencies {
     testImplementation "io.spine:spine-testlib:$spineBaseVersion"
     testImplementation project(path: ':testutil-time')
 }
+
+modelCompiler {
+    generateValidation = true
+}

--- a/time/src/main/java/io/spine/time/validate/When.java
+++ b/time/src/main/java/io/spine/time/validate/When.java
@@ -20,19 +20,18 @@
 
 package io.spine.time.validate;
 
-import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
+import io.spine.code.proto.FieldContext;
 import io.spine.time.validation.TimeOption;
 import io.spine.time.validation.TimeOptionsProto;
-import io.spine.validate.FieldValue;
-import io.spine.validate.option.Constraint;
+import io.spine.validate.Constraint;
 import io.spine.validate.option.FieldValidatingOption;
 
 /**
  * A validating option that specified the point in time which a {@link Timestamp} field value
  * has.
  */
-final class When extends FieldValidatingOption<TimeOption, Message> {
+final class When extends FieldValidatingOption<TimeOption> {
 
     private When() {
         super(TimeOptionsProto.when);
@@ -44,7 +43,7 @@ final class When extends FieldValidatingOption<TimeOption, Message> {
     }
 
     @Override
-    public Constraint<FieldValue<Message>> constraintFor(FieldValue<Message> value) {
-        return new WhenConstraint(optionValue(value));
+    public Constraint constraintFor(FieldContext value) {
+        return new WhenConstraint(optionValue(value), value.targetDeclaration());
     }
 }

--- a/time/src/main/java/io/spine/time/validate/WhenConstraint.java
+++ b/time/src/main/java/io/spine/time/validate/WhenConstraint.java
@@ -73,7 +73,7 @@ final class WhenConstraint
 
     @Override
     public String errorMessage(FieldContext context) {
-        return "";
+        return ViolationText.errorMessage(optionValue(), optionValue().getMsgFormat());
     }
 
     /**
@@ -94,7 +94,7 @@ final class WhenConstraint
     }
 
     private ConstraintViolation newTimeViolation(FieldValue fieldValue, Temporal<?> value) {
-        String msg = ViolationText.errorMessage(optionValue(), optionValue().getMsgFormat());
+        String msg = errorMessage(fieldValue.context());
         String when = optionValue().getIn()
                                    .toString()
                                    .toLowerCase();

--- a/time/src/main/java/io/spine/time/validate/WhenConstraint.java
+++ b/time/src/main/java/io/spine/time/validate/WhenConstraint.java
@@ -44,9 +44,7 @@ import static io.spine.time.validation.Time.TIME_UNDEFINED;
  * A constraint that, when applied to a {@link Timestamp} field value, checks for whether the
  * actual value is in the future or in the past, defined by the value of the field option.
  */
-final class WhenConstraint
-        extends FieldConstraint<TimeOption>
-        implements CustomConstraint {
+final class WhenConstraint extends FieldConstraint<TimeOption> implements CustomConstraint {
 
     WhenConstraint(TimeOption optionValue, FieldDeclaration field) {
         super(optionValue, field);

--- a/time/src/main/java/io/spine/time/validate/WhenFactory.java
+++ b/time/src/main/java/io/spine/time/validate/WhenFactory.java
@@ -23,7 +23,6 @@ package io.spine.time.validate;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
-import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.validate.option.FieldValidatingOption;
 import io.spine.validate.option.ValidatingOptionFactory;
@@ -39,11 +38,11 @@ import java.util.Set;
 @Immutable
 public final class WhenFactory implements ValidatingOptionFactory {
 
-    private static final ImmutableSet<FieldValidatingOption<?, Message>> TYPE_OPTIONS =
+    private static final ImmutableSet<FieldValidatingOption<?>> TYPE_OPTIONS =
             ImmutableSet.of(When.create());
 
     @Override
-    public Set<FieldValidatingOption<?, Message>> forMessage() {
+    public Set<FieldValidatingOption<?>> forMessage() {
         return TYPE_OPTIONS;
     }
 }

--- a/time/src/test/java/io/spine/time/validate/WhenFactoryTest.java
+++ b/time/src/test/java/io/spine/time/validate/WhenFactoryTest.java
@@ -21,7 +21,6 @@
 package io.spine.time.validate;
 
 import com.google.common.collect.Iterables;
-import com.google.protobuf.Message;
 import io.spine.validate.option.FieldValidatingOption;
 import io.spine.validate.option.ValidatingOptionFactory;
 import org.junit.jupiter.api.DisplayName;
@@ -57,9 +56,9 @@ class WhenFactoryTest {
     @DisplayName("declare (when) option")
     void declareWhen() {
         ValidatingOptionFactory factory = new WhenFactory();
-        Set<FieldValidatingOption<?, Message>> messageOptions = factory.forMessage();
+        Set<FieldValidatingOption<?>> messageOptions = factory.forMessage();
         assertThat(messageOptions).hasSize(1);
-        FieldValidatingOption<?, Message> option = Iterables.getOnlyElement(messageOptions);
+        FieldValidatingOption<?> option = Iterables.getOnlyElement(messageOptions);
         assertThat(option).isInstanceOf(When.class);
     }
 }

--- a/time/src/test/java/io/spine/time/validate/WhenTest.java
+++ b/time/src/test/java/io/spine/time/validate/WhenTest.java
@@ -39,6 +39,7 @@ import static io.spine.time.validate.given.WhenTestEnv.freezeTime;
 import static io.spine.time.validate.given.WhenTestEnv.future;
 import static io.spine.time.validate.given.WhenTestEnv.past;
 import static io.spine.time.validate.given.WhenTestEnv.timeWithNanos;
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -166,7 +167,7 @@ class WhenTest {
                 .newBuilder()
                 .setDuration(Duration.getDefaultInstance())
                 .build();
-        assertThrows(IllegalArgumentException.class, () -> failingMessage.validate());
+        assertThrows(IllegalArgumentException.class, failingMessage::validate);
     }
 
     private void validate(MessageWithConstraints msg) {

--- a/time/src/test/java/io/spine/time/validate/WhenTest.java
+++ b/time/src/test/java/io/spine/time/validate/WhenTest.java
@@ -21,11 +21,10 @@
 package io.spine.time.validate;
 
 import com.google.protobuf.Duration;
-import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import io.spine.base.Time;
+import io.spine.protobuf.MessageWithConstraints;
 import io.spine.validate.ConstraintViolation;
-import io.spine.validate.MessageValidator;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +39,6 @@ import static io.spine.time.validate.given.WhenTestEnv.freezeTime;
 import static io.spine.time.validate.given.WhenTestEnv.future;
 import static io.spine.time.validate.given.WhenTestEnv.past;
 import static io.spine.time.validate.given.WhenTestEnv.timeWithNanos;
-import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -168,23 +166,23 @@ class WhenTest {
                 .newBuilder()
                 .setDuration(Duration.getDefaultInstance())
                 .build();
-        assertThrows(IllegalArgumentException.class, () -> validate(failingMessage));
+        assertThrows(IllegalArgumentException.class, () -> failingMessage.validate());
     }
 
-    private void validate(Message msg) {
-        violations = MessageValidator.validate(msg);
+    private void validate(MessageWithConstraints msg) {
+        violations = msg.validate();
     }
 
     private ConstraintViolation firstViolation() {
         return violations.get(0);
     }
 
-    private void assertValid(Message msg) {
+    private void assertValid(MessageWithConstraints msg) {
         validate(msg);
         assertIsValid(true);
     }
 
-    private void assertNotValid(Message msg) {
+    private void assertNotValid(MessageWithConstraints msg) {
         validate(msg);
         assertIsValid(false);
     }
@@ -218,7 +216,7 @@ class WhenTest {
         }
     }
 
-    private void assertSingleViolation(Message message, String expectedErrMsg) {
+    private void assertSingleViolation(MessageWithConstraints message, String expectedErrMsg) {
         assertNotValid(message);
         assertNotNull(violations);
         assertEquals(1, violations.size());

--- a/version.gradle
+++ b/version.gradle
@@ -20,7 +20,7 @@
 
 ext {
     // The version of the Spine Base module to be used in this project.
-    spineBaseVersion = '1.3.0'
+    spineBaseVersion = '1.3.2'
 
     // Publish this library with the same version number as Base.
     versionToPublish = spineBaseVersion


### PR DESCRIPTION
In this PR we migrate the library to `base` of version `1.3.2`, which includes the generated validation code.

Code generation for `time` types is turned on.

The version is updated to `1.3.2`.