### PR TITLE
Update to 1.5.18

### DIFF
--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -18,6 +18,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val spineBaseVersion: String by extra("1.5.15")
+val spineBaseVersion: String by extra("1.5.18")
 
 extra["versionToPublish"] = spineBaseVersion


### PR DESCRIPTION
This PR updates the time library version to match that of the most recent base: `1.5.18`.