### PR TITLE
Fail build on warnings

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -70,7 +70,7 @@ object Versions {
     val checkerFramework = "3.3.0"
     val errorProne       = "2.3.4"
     val errorProneJavac  = "9+181-r4173-1" // taken from here: https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
-    val errorPronePlugin = "1.1.1"
+    val errorPronePlugin = "1.2.1"
     val pmd              = "6.24.0"
     val checkstyle       = "8.29"
     val protobufPlugin   = "0.8.12"
@@ -102,7 +102,7 @@ object Versions {
     /**
      * Version of the SLF4J library.
      *
-     * Spine used to log with SLF4J. Now we use Flogger. Whenever a coice comes up, we recommend to
+     * Spine used to log with SLF4J. Now we use Flogger. Whenever a choice comes up, we recommend to
      * use the latter.
      *
      * Some third-party libraries may clash with different versions of the library. Thus, we specify
@@ -229,7 +229,7 @@ object Test {
             "com.google.truth.extensions:truth-proto-extension:${Versions.truth}"
     )
     @Deprecated("Use Flogger over SLF4J.",
-                replaceWith = ReplaceWith("Deps.runtime.floggerSystemBackend"))
+            replaceWith = ReplaceWith("Deps.runtime.floggerSystemBackend"))
     @Suppress("DEPRECATION") // Version of SLF4J.
     val slf4j         = "org.slf4j:slf4j-jdk14:${Versions.slf4j}"
 }

--- a/time/src/main/proto/spine/time/time.proto
+++ b/time/src/main/proto/spine/time/time.proto
@@ -30,7 +30,6 @@ option java_outer_classname = "TimeProto";
 option java_package = "io.spine.time";
 
 import "google/protobuf/timestamp.proto";
-import "google/protobuf/duration.proto";
 
 // Enum representing the 12 months of the year.
 enum Month {
@@ -84,7 +83,7 @@ enum DayOfWeek {
 message LocalDate {
     option (is).java_type = "io.spine.time.LocalDateTemporal";
 
-    // A year with `1` being year 1 CE and `-1` being 1 BC. 
+    // A year with `1` being year 1 CE and `-1` being 1 BC.
     int32 year = 1;
 
     // One of 12 Gregorian calendar months specified by `Month`.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -18,6 +18,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val spineBaseVersion: String by extra("1.5.19")
+val spineBaseVersion: String by extra("1.5.20")
 
 extra["versionToPublish"] = spineBaseVersion

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -18,6 +18,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val spineBaseVersion: String by extra("1.5.20")
+val spineBaseVersion: String by extra("1.5.21")
 
 extra["versionToPublish"] = spineBaseVersion


### PR DESCRIPTION
This PR prepares `time` for SpineEventEngine/config#122.

It makes sure that the build yields no warnings.