### PR TITLE
Version increment check

### DIFF
--- a/.github/workflows/increment_guard.yml
+++ b/.github/workflows/increment_guard.yml
@@ -1,0 +1,26 @@
+# Ensures that the current lib version is not yet published but executing the Gradle
+# `checkVersionIncrement` task.
+
+name: Check version increment
+
+on:
+  push:
+    branches: '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Pull config
+        run: git submodule update --init --recursive
+
+      - name: Check version is not yet published
+        shell: bash
+        run: ./gradlew checkVersionIncrement

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,12 +34,12 @@
 /**
  * Version of this library.
  */
-val time = "1.6.11"
+val time = "1.6.13"
 
 /**
  * Versions of the Spine libraries that `time` depends on.
  */
-val base = "1.6.11"
+val base = "1.6.13"
 
 project.extra.apply {
     this["versionToPublish"] = time


### PR DESCRIPTION
In this PR we add a new GitHub Actions check which invokes the `checkVersionIncrement` Gradle task.

The check fails if the current version of the library is already published in order to avoid overriding existing versions.
The check runs on any `push`, but the task is only enabled for all branches except `master`. On `master`, the check will always pass.