### PR TITLE
Add `isBefore()` and `isAfter()` extensions for `Timestamp`

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -76,6 +76,8 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="BUILDER_METHODS" value="newBuilder,builder,toBuilder" />
+      <option name="KEEP_BUILDER_METHODS_INDENTS" value="true" />
       <arrangement>
         <groups>
           <group>

--- a/license-report.md
+++ b/license-report.md
@@ -412,7 +412,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Apr 11 11:26:47 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 12 12:34:58 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -862,4 +862,4 @@ This report was generated on **Sun Apr 11 11:26:47 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Apr 11 11:26:56 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 12 12:35:07 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/time/src/main/kotlin/io/spine/time/DurationExtensions.kt
+++ b/time/src/main/kotlin/io/spine/time/DurationExtensions.kt
@@ -136,7 +136,7 @@ public fun Duration.toMinutes(): Long = toMinutes(this)
  * @return the number of seconds rounded towards 0 to the nearest second.
  *         E.g., if the duration represents -1 nanosecond, it will be rounded to 0.
  */
-public fun Duration.toSeconds(): Long = toSeconds(this);
+public fun Duration.toSeconds(): Long = toSeconds(this)
 
 /**
  * Convert this duration to the number of milliseconds.
@@ -162,7 +162,7 @@ public fun Duration.toNanos(): Long = toNanos(this)
 /**
  * Converts this duration to Java Time instance.
  */
-public fun Duration.toJavaTime(): java.time.Duration = toJavaTime(this);
+public fun Duration.toJavaTime(): java.time.Duration = toJavaTime(this)
 
 /**
  * Adds the passed duration to this one.

--- a/time/src/main/kotlin/io/spine/time/TimestampExtensions.kt
+++ b/time/src/main/kotlin/io/spine/time/TimestampExtensions.kt
@@ -61,6 +61,18 @@ public fun Timestamp.isBefore(other: Timestamp): Boolean = this < other
 public fun Timestamp.isAfter(other: Timestamp): Boolean = this > other
 
 /**
+ * Checks if this point is time lies between the given.
+ *
+ * @param periodStart
+ *         lower bound, exclusive
+ * @param periodEnd
+ *         higher bound, inclusive
+ * @return `true` if this point in time lies in between the given two, `false` otherwise
+ */
+public fun Timestamp.isBetween(periodStart: Timestamp, periodEnd: Timestamp): Boolean =
+    this > periodStart && this <= periodEnd
+
+/**
  * Returns true if this instance is valid.
  *
  * The [seconds][Timestamp.getSeconds] value must be in the range

--- a/time/src/main/kotlin/io/spine/time/TimestampExtensions.kt
+++ b/time/src/main/kotlin/io/spine/time/TimestampExtensions.kt
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:JvmName("TimestampExtensions")
+
 package io.spine.time
 
 import com.google.protobuf.Duration
@@ -47,6 +49,16 @@ import com.google.protobuf.util.Timestamps.toString
  * - a value greater than `0` if `this > other`.
  */
 public operator fun Timestamp.compareTo(other: Timestamp): Int = compare(this, other)
+
+/**
+ * Verifies whether this point in time is before the passed one.
+ */
+public fun Timestamp.isBefore(other: Timestamp): Boolean = this < other
+
+/**
+ * Verifies whether this point in time is after the passed one.
+ */
+public fun Timestamp.isAfter(other: Timestamp): Boolean = this > other
 
 /**
  * Returns true if this instance is valid.

--- a/time/src/main/kotlin/io/spine/time/TimestampExtensions.kt
+++ b/time/src/main/kotlin/io/spine/time/TimestampExtensions.kt
@@ -39,6 +39,7 @@ import com.google.protobuf.util.Timestamps.toMicros
 import com.google.protobuf.util.Timestamps.toMillis
 import com.google.protobuf.util.Timestamps.toNanos
 import com.google.protobuf.util.Timestamps.toString
+import java.time.Instant
 
 /**
  * Compares this timestamp with the passed one.
@@ -146,3 +147,8 @@ public operator fun Timestamp.minus(other: Timestamp): Duration = between(this, 
  * Subtracts a duration from this timestamp.
  */
 public operator fun Timestamp.minus(length: Duration): Timestamp = subtract(this, length)
+
+/**
+ * Converts this timestamp to `Instant`.
+ */
+public fun Timestamp.toInstant(): Instant = InstantConverter.reversed().convert(this)!!

--- a/time/src/test/java/io/spine/time/validate/WhenTest.java
+++ b/time/src/test/java/io/spine/time/validate/WhenTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.spine.time.validate.given.WhenTestEnv.FIFTY_NANOSECONDS;
 import static io.spine.time.validate.given.WhenTestEnv.ZERO_NANOSECONDS;
 import static io.spine.time.validate.given.WhenTestEnv.currentTimeWithNanos;
@@ -66,8 +67,7 @@ class WhenTest {
     @Test
     @DisplayName("find out that time is in future")
     void findOutThatTimeIsInFuture() {
-        TimeInFutureFieldValue validMsg = TimeInFutureFieldValue
-                .newBuilder()
+        TimeInFutureFieldValue validMsg = TimeInFutureFieldValue.newBuilder()
                 .setValue(future())
                 .build();
         assertValid(validMsg);
@@ -76,8 +76,7 @@ class WhenTest {
     @Test
     @DisplayName("find out that time is NOT in future")
     void findOutThatTimeIsNotInFuture() {
-        TimeInFutureFieldValue invalidMsg = TimeInFutureFieldValue
-                .newBuilder()
+        TimeInFutureFieldValue invalidMsg = TimeInFutureFieldValue.newBuilder()
                 .setValue(past())
                 .build();
         assertNotValid(invalidMsg);
@@ -86,8 +85,7 @@ class WhenTest {
     @Test
     @DisplayName("find out that time is in past")
     void findOutThatTimeIsInPast() {
-        TimeInPastFieldValue validMsg = TimeInPastFieldValue
-                .newBuilder()
+        TimeInPastFieldValue validMsg = TimeInPastFieldValue.newBuilder()
                 .setValue(past())
                 .build();
         assertValid(validMsg);
@@ -96,8 +94,7 @@ class WhenTest {
     @Test
     @DisplayName("find out that time is NOT in past")
     void findOutThatTimeIsNotInPast() {
-        TimeInPastFieldValue invalidMsg = TimeInPastFieldValue
-                .newBuilder()
+        TimeInPastFieldValue invalidMsg = TimeInPastFieldValue.newBuilder()
                 .setValue(future())
                 .build();
         assertNotValid(invalidMsg);
@@ -109,10 +106,9 @@ class WhenTest {
         Timestamp currentTime = currentTimeWithNanos(ZERO_NANOSECONDS);
         Timestamp timeInFuture = timeWithNanos(currentTime, FIFTY_NANOSECONDS);
         freezeTime(currentTime);
-        TimeInPastFieldValue invalidMsg =
-                TimeInPastFieldValue.newBuilder()
-                                    .setValue(timeInFuture)
-                                    .build();
+        TimeInPastFieldValue invalidMsg = TimeInPastFieldValue.newBuilder()
+                .setValue(timeInFuture)
+                .build();
         assertNotValid(invalidMsg);
     }
 
@@ -122,10 +118,9 @@ class WhenTest {
         Timestamp currentTime = currentTimeWithNanos(FIFTY_NANOSECONDS);
         Timestamp timeInPast = timeWithNanos(currentTime, ZERO_NANOSECONDS);
         freezeTime(currentTime);
-        TimeInPastFieldValue invalidMsg =
-                TimeInPastFieldValue.newBuilder()
-                                    .setValue(timeInPast)
-                                    .build();
+        TimeInPastFieldValue invalidMsg = TimeInPastFieldValue.newBuilder()
+                .setValue(timeInPast)
+                .build();
         assertValid(invalidMsg);
     }
 
@@ -139,8 +134,7 @@ class WhenTest {
     @Test
     @DisplayName("provide one valid violation if time is invalid")
     void provideOneValidViolationIfTimeIsInvalid() {
-        TimeInFutureFieldValue invalidMsg = TimeInFutureFieldValue
-                .newBuilder()
+        TimeInFutureFieldValue invalidMsg = TimeInFutureFieldValue.newBuilder()
                 .setValue(past())
                 .build();
         assertSingleViolation(invalidMsg, "Point in time must be in the future.");
@@ -149,8 +143,7 @@ class WhenTest {
     @Test
     @DisplayName("ignore (when).in = TIME_UNDEFINED if in the past")
     void ignoreTimeUndefinedInFuture() {
-        AlwaysValidTime validTimeInPast = AlwaysValidTime
-                .newBuilder()
+        AlwaysValidTime validTimeInPast = AlwaysValidTime.newBuilder()
                 .setValue(past())
                 .build();
         assertValid(validTimeInPast);
@@ -159,8 +152,7 @@ class WhenTest {
     @Test
     @DisplayName("ignore (when).in = TIME_UNDEFINED if in the future")
     void ignoreTimeUndefinedInPast() {
-        AlwaysValidTime validTimeInPast = AlwaysValidTime
-                .newBuilder()
+        AlwaysValidTime validTimeInPast = AlwaysValidTime.newBuilder()
                 .setValue(future())
                 .build();
         assertValid(validTimeInPast);
@@ -233,10 +225,12 @@ class WhenTest {
     /** Checks that a message is not valid and has a single violation. */
     private void assertSingleViolation(String expectedErrMsg) {
         ConstraintViolation violation = firstViolation();
-        String actualErrorMessage = format(violation.getMsgFormat(), violation.getParamList()
-                                                                              .toArray());
-        assertEquals(expectedErrMsg, actualErrorMessage);
-        assertTrue(violation.getViolationList()
-                            .isEmpty());
+        String actualErrorMessage =
+                format(violation.getMsgFormat(), violation.getParamList().toArray());
+
+        assertThat(actualErrorMessage)
+                .isEqualTo(expectedErrMsg);
+        assertThat(violation.getViolationList())
+                .isEmpty();
     }
 }

--- a/time/src/test/kotlin/io/spine/time/TimestampExtensionsTest.kt
+++ b/time/src/test/kotlin/io/spine/time/TimestampExtensionsTest.kt
@@ -87,6 +87,12 @@ internal class `Timestamp extensions should` {
             assertFalse(past.isAfter(future))
             assertFalse(future.isAfter(future))
         }
+
+        @Test
+        fun `between two other`() {
+            assertTrue(inBetween.isBetween(past, future))
+            assertFalse(past.isBetween(inBetween, future))
+        }
     }
 
     @Nested

--- a/time/src/test/kotlin/io/spine/time/TimestampExtensionsTest.kt
+++ b/time/src/test/kotlin/io/spine/time/TimestampExtensionsTest.kt
@@ -69,6 +69,9 @@ internal class `Timestamp extensions should` {
 
         @Test
         fun toNanos() = assertThat(past.toNanos()).isEqualTo(toNanos(past))
+
+        @Test
+        fun instant() = assertThat(past.toInstant()).isEqualTo(past().toInstant())
     }
 
     @Nested

--- a/time/src/test/kotlin/io/spine/time/TimestampExtensionsTest.kt
+++ b/time/src/test/kotlin/io/spine/time/TimestampExtensionsTest.kt
@@ -72,6 +72,24 @@ internal class `Timestamp extensions should` {
     }
 
     @Nested
+    inner class `Tell if this time is` {
+
+        @Test
+        fun `before another`() {
+            assertTrue(past.isBefore(future))
+            assertFalse(future.isBefore(past))
+            assertFalse(past.isBefore(past))
+        }
+
+        @Test
+        fun `after another`() {
+            assertTrue(future.isAfter(past))
+            assertFalse(past.isAfter(future))
+            assertFalse(future.isAfter(future))
+        }
+    }
+
+    @Nested
     inner class `Provide operators` {
 
         @Test

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -40,7 +40,7 @@
 /**
  * Version of this library.
  */
-val time = "2.0.0-SNAPSHOT.15"
+val time = "2.0.0-SNAPSHOT.17"
 
 /**
  * Versions of the Spine libraries that `time` depends on.


### PR DESCRIPTION
This PR:
  * Addresses deprecations in tests.
  * Fixes JVM file name for `TimestampExtensions.kt` (avoiding the `Kt` suffix).
  * Adds `Timestamp.isBefore()` and `Timestamp.isAfter()` extensions.