### PR TITLE
Fix publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,14 +40,15 @@ buildscript {
     apply(from = "$rootDir/version.gradle.kts")
 
     @Suppress("RemoveRedundantQualifierName") // Cannot use imports here.
-    val resolution = io.spine.gradle.internal.DependencyResolution
-    resolution.defaultRepositories(repositories)
+    io.spine.gradle.internal.applyStandard(repositories)
 
     val spineBaseVersion: String by extra
     dependencies {
         classpath("io.spine.tools:spine-model-compiler:$spineBaseVersion")
     }
 
+    @Suppress("RemoveRedundantQualifierName") // Cannot use imports here.
+    val resolution = io.spine.gradle.internal.DependencyResolution
     resolution.forceConfiguration(configurations)
 }
 

--- a/license-report.md
+++ b/license-report.md
@@ -408,7 +408,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Apr 12 16:13:14 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 12 16:45:12 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -854,4 +854,4 @@ This report was generated on **Mon Apr 12 16:13:14 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Apr 12 16:13:24 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 12 16:45:19 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,9 +25,8 @@
  */
 pluginManagement {
     repositories {
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
+        gradlePluginPortal()
         mavenCentral()
-        maven("https://plugins.gradle.org/m2/")
     }
 }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -40,7 +40,7 @@
 /**
  * Version of this library.
  */
-val time = "2.0.0-SNAPSHOT.17"
+val time = "2.0.0-SNAPSHOT.18"
 
 /**
  * Versions of the Spine libraries that `time` depends on.
@@ -51,3 +51,4 @@ project.extra.apply {
     this["versionToPublish"] = time
     this["spineBaseVersion"] = base
 }
+


### PR DESCRIPTION
This PR addresses deprecation in the build script and removes the usage of Bintray Gradle Plugin repository, which was turned off.