### PR TITLE
Document validation error message format in `time_options.proto`

### DIFF
--- a/buildSrc/src/main/groovy/slow-tests.gradle
+++ b/buildSrc/src/main/groovy/slow-tests.gradle
@@ -25,7 +25,7 @@
  */
 
 println("`slow-tests.gradle` script is deprecated. " +
-        "Please use `TestContainer.registerTestTasks()` instead.")
+        "Please use `TaskContainer.registerTestTasks()` instead.")
 
 final def slowTag = 'slow' // See io.spine.testing.SlowTest
 

--- a/buildSrc/src/main/groovy/test-artifacts.gradle
+++ b/buildSrc/src/main/groovy/test-artifacts.gradle
@@ -29,6 +29,10 @@
 //
 // testCompile project(path: ":projectWithTests", configuration: 'testArtifacts')
 //
+
+println("`test-artifacts.gradle` script is deprecated. " +
+        "Please use the `Project.exposeTestArtifacts()` utility instead.")
+
 configurations {
     testArtifacts.extendsFrom testRuntime
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/coverage/JacocoConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/coverage/JacocoConfig.kt
@@ -34,7 +34,6 @@ import io.spine.internal.gradle.report.coverage.TaskName.jacocoRootReport
 import io.spine.internal.gradle.report.coverage.TaskName.jacocoTestReport
 import io.spine.internal.gradle.sourceSets
 import java.io.File
-import java.lang.IllegalStateException
 import java.util.*
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -62,6 +61,7 @@ import org.gradle.testing.jacoco.tasks.JacocoReport
  * Therefore, tn case this utility is applied to a single-module Gradle project,
  * an `IllegalStateException` is thrown.
  */
+@Suppress("unused")
 class JacocoConfig(
     private val rootProject: Project,
     private val reportsDir: File,
@@ -112,7 +112,7 @@ class JacocoConfig(
                 } else {
                     throw IllegalStateException(
                         "In a single-module Gradle project, `JacocoConfig` is NOT needed." +
-                                "Please apply `jacoco` plugin instead."
+                                " Please apply `jacoco` plugin instead."
                     )
                 }
             return projects

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Artifacts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Artifacts.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.testing
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Exposes the test classes of this project as a new `testArtifacts` configuration.
+ *
+ * This allows other Gradle projects to depend on the test classes of some project. It is helpful
+ * in case the dependant projects re-use abstract test suites of some "parent" project.
+ *
+ * Please note that this utility requires Gradle `java` plugin to be applied.
+ * Hence, it is recommended to call this extension method from `java` scope:
+ *
+ * ```
+ * java {
+ *     exposeTestArtifacts()
+ * }
+ * ```
+ *
+ * Here is a snippet which consumes the exposed test classes:
+ *
+ * ```
+ * dependencies {
+ *     testImplementation(project(path = ":projectName", configuration = "testArtifacts"))
+ * }
+ * ```
+ */
+fun Project.exposeTestArtifacts() {
+
+    val testArtifacts = configurations.create("testArtifacts") {
+        extendsFrom(configurations.getAt("testRuntimeClasspath"))
+    }
+
+    val sourceSets = extensions.getByType<JavaPluginExtension>().sourceSets
+    val testJar = tasks.register<Jar>("testJar") {
+        archiveClassifier.set("test")
+        from(sourceSets.getAt("test").output)
+    }
+
+    artifacts.add(testArtifacts.name, testJar)
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Logging.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.testing
+
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.TestDescriptor
+import org.gradle.api.tasks.testing.TestResult
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.kotlin.dsl.KotlinClosure2
+
+/**
+ * Configures logging of this [Test] task.
+ *
+ * Enables logging of:
+ *  1. Standard `out` and `err` streams;
+ *  2. Thrown exceptions.
+ *
+ *  Additionally, after all the tests are executed, a short summary would be logged. The summary
+ *  consists of the number of tests and their results.
+ *
+ * Usage example:
+ *
+ *```
+ * tasks {
+ *     withType<Test> {
+ *         configureLogging()
+ *     }
+ * }
+ *```
+ */
+fun Test.configureLogging() {
+    testLogging {
+        showStandardStreams = true
+        showExceptions = true
+        exceptionFormat = TestExceptionFormat.FULL
+        showStackTraces = true
+        showCauses = true
+    }
+
+    fun TestResult.summary(): String =
+        """
+        Test summary:
+        >> $testCount tests
+        >> $successfulTestCount succeeded
+        >> $failedTestCount failed
+        >> $skippedTestCount skipped
+        """
+
+    afterSuite(
+
+        // `GroovyInteroperability` is employed as `afterSuite()` has no equivalent in Kotlin DSL.
+        // See issue: https://github.com/gradle/gradle/issues/5431
+
+        KotlinClosure2<TestDescriptor, TestResult, Unit>({ descriptor, result ->
+
+            // If the descriptor has no parent, then it is the root test suite,
+            // i.e. it includes the info about all the run tests.
+
+            if (descriptor.parent == null) {
+                logger.lifecycle(result.summary())
+            }
+        })
+    )
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Tasks.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Tasks.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.testing
+
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Registers [slowTest][SlowTest] and [fastTest][FastTest] tasks in this [TaskContainer].
+ *
+ * Slow tests are registered to run after all fast tests.
+ *
+ * Usage example:
+ *
+ * ```
+ * tasks {
+ *     registerTestTasks()
+ * }
+ * ```
+ */
+@Suppress("unused")
+fun TaskContainer.registerTestTasks() {
+    register<FastTest>("fastTest").let {
+        register<SlowTest>("slowTest") {
+            shouldRunAfter(it)
+        }
+    }
+}
+
+/**
+ * Name of a tag for annotating a test class or method that is known to be slow and
+ * should not normally be run together with the main test suite.
+ *
+ * @see [SlowTest](https://spine.io/base/reference/testlib/io/spine/testing/SlowTest.html)
+ * @see [Tag](https://junit.org/junit5/docs/5.0.2/api/org/junit/jupiter/api/Tag.html)
+ */
+private const val SLOW_TAG = "slow"
+
+/**
+ * Executes JUnit tests filtering out the ones tagged as `slow`.
+ */
+private open class FastTest : Test() {
+    init {
+        description = "Executes all JUnit tests but the ones tagged as `slow`."
+        group = "Verification"
+
+        this.useJUnitPlatform {
+            excludeTags(SLOW_TAG)
+        }
+    }
+}
+
+/**
+ * Executes JUnit tests tagged as `slow`.
+ */
+private open class SlowTest : Test() {
+    init {
+        description = "Executes JUnit tests tagged as `slow`."
+        group = "Verification"
+
+        this.useJUnitPlatform {
+            includeTags(SLOW_TAG)
+        }
+    }
+}

--- a/license-report.md
+++ b/license-report.md
@@ -397,7 +397,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 11:31:07 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 13:35:42 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -828,4 +828,4 @@ This report was generated on **Wed Nov 10 11:31:07 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 11:31:11 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 13:35:43 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-testutil-time:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.tools:spine-testutil-time:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -397,12 +397,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 08 15:25:51 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 11:31:07 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -828,4 +828,4 @@ This report was generated on **Mon Nov 08 15:25:51 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 08 15:25:52 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 11:31:11 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.74</version>
+    <version>2.0.0-SNAPSHOT.75</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -44,7 +44,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.74</version>
+    <version>2.0.0-SNAPSHOT.75</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -93,13 +93,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-checks</artifactId>
-    <version>2.0.0-SNAPSHOT.74</version>
+    <version>2.0.0-SNAPSHOT.75</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-protoc</artifactId>
-    <version>2.0.0-SNAPSHOT.74</version>
+    <version>2.0.0-SNAPSHOT.75</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-time</artifactId>
-<version>2.0.0-SNAPSHOT.74</version>
+<version>2.0.0-SNAPSHOT.75</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/time/src/main/java/io/spine/time/validate/WhenConstraint.java
+++ b/time/src/main/java/io/spine/time/validate/WhenConstraint.java
@@ -76,8 +76,7 @@ final class WhenConstraint extends FieldConstraint<TimeOption> implements Custom
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-        // Old error message format. Discontinued along with the old validation library.
+    @SuppressWarnings("deprecation") /* Old validation won't migrate to the new error messages. */
     public String errorMessage(FieldContext context) {
         return ViolationText.errorMessage(optionValue(), optionValue().getMsgFormat());
     }

--- a/time/src/main/java/io/spine/time/validate/WhenConstraint.java
+++ b/time/src/main/java/io/spine/time/validate/WhenConstraint.java
@@ -76,6 +76,8 @@ final class WhenConstraint extends FieldConstraint<TimeOption> implements Custom
     }
 
     @Override
+    @SuppressWarnings("deprecation")
+        // Old error message format. Discontinued along with the old validation library.
     public String errorMessage(FieldContext context) {
         return ViolationText.errorMessage(optionValue(), optionValue().getMsgFormat());
     }

--- a/time/src/main/proto/spine/time_options.proto
+++ b/time/src/main/proto/spine/time_options.proto
@@ -76,7 +76,14 @@ message TimeOption {
     Time in = 1;
 
     // A user-defined validation error format message.
-    string msg_format = 2;
+    string msg_format = 2 [deprecated = true];
+
+    // A user-defined validation error format message.
+    //
+    // May include tokens `{value}`—for the actual value of the field, and `{other}`—for
+    // the threshold value. The tokens will be replaced at runtime when the error is constructed.
+    //
+    string error_msg = 3;
 }
 
 // This enumeration defines restriction for date/time values.

--- a/time/src/main/proto/spine/time_options.proto
+++ b/time/src/main/proto/spine/time_options.proto
@@ -84,7 +84,7 @@ message TimeOption {
     // A user-defined validation error format message.
     //
     // May include tokens `{value}`—for the actual value of the field, and `{other}`—for
-    // the threshold value. The tokens will be replaced at runtime when the error is constructed.
+    // the expected value. The tokens will be replaced at runtime when the error is constructed.
     //
     string error_msg = 3;
 }

--- a/time/src/main/proto/spine/time_options.proto
+++ b/time/src/main/proto/spine/time_options.proto
@@ -76,6 +76,9 @@ message TimeOption {
     Time in = 1;
 
     // A user-defined validation error format message.
+    //
+    // Deprecated. Use `error_msg` instead.
+    //
     string msg_format = 2 [deprecated = true];
 
     // A user-defined validation error format message.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,7 +25,7 @@
  */
 
 /** Versions of the Spine libraries that `time` depends on. */
-val spineBaseVersion by extra("2.0.0-SNAPSHOT.74")
+val spineBaseVersion by extra("2.0.0-SNAPSHOT.75")
 val javadocToolsVersion by extra("2.0.0-SNAPSHOT.74")
 
 /** The version of this library. */

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@ val spineBaseVersion by extra("2.0.0-SNAPSHOT.74")
 val javadocToolsVersion by extra("2.0.0-SNAPSHOT.74")
 
 /** The version of this library. */
-val versionToPublish by extra("2.0.0-SNAPSHOT.74")
+val versionToPublish by extra("2.0.0-SNAPSHOT.75")


### PR DESCRIPTION
In this PR we move from using the `String.format(..)` syntax for the constraint violation messages to the new syntax with placeholders.

The validation will eventually be removed from `base` and `time`. Thus, we only modify the option declaration. The old validation lib parts are left intact.