### PR TITLE
Release 1.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# Copyright 2022, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Spine Time: Protobuf-based Date/Time types
 
-[![Build Status][travis-badge]][travis] &nbsp; 
 [![codecov][codecov-badge]][codecov] &nbsp;
 [![license][license-badge]][license]
 
@@ -27,8 +26,6 @@ In addition to the generated types and basic factory and calculation routines, t
 provides converters between its types and Java Time. It is expected that an application would 
 perform the date/time calculations using Java Time.
 
-[travis]: https://travis-ci.com/SpineEventEngine/time
-[travis-badge]: https://travis-ci.com/SpineEventEngine/time.svg?branch=master
 [codecov]: https://codecov.io/gh/SpineEventEngine/time
 [codecov-badge]: https://codecov.io/gh/SpineEventEngine/time/branch/master/graph/badge.svg
 [license-badge]: https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The types provided by this library follow the conventions offered by [Java Time]
 
 ## Supported Languages
 
-Currently the library supports only Java, with JavaScript and Dart being on the priority list.
+Currently, the library supports only Java, with JavaScript and Dart being on the priority list.
  
 ## Using Spine Time in a Java Project
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-testutil-time:1.9.0-SNAPSHOT.5`
+# Dependencies of `io.spine:spine-testutil-time:1.9.0`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -327,12 +327,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Nov 09 12:42:19 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 18 14:46:49 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-time:1.9.0-SNAPSHOT.5`
+# Dependencies of `io.spine:spine-time:1.9.0`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -692,4 +692,4 @@ This report was generated on **Wed Nov 09 12:42:19 TRT 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Nov 09 12:42:32 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 18 14:47:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-time</artifactId>
-<version>1.9.0-SNAPSHOT.5</version>
+<version>1.9.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -46,7 +46,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -58,7 +58,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -143,18 +143,18 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-errorprone-checks</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/pull
+++ b/pull
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright 2022, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/time/build.gradle.kts
+++ b/time/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/time/src/main/java/io/spine/time/InstantConverter.java
+++ b/time/src/main/java/io/spine/time/InstantConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/time/src/main/java/io/spine/time/LocalDateTemporal.java
+++ b/time/src/main/java/io/spine/time/LocalDateTemporal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/time/src/main/java/io/spine/time/LocalDates.java
+++ b/time/src/main/java/io/spine/time/LocalDates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/time/src/main/java/io/spine/time/LocalTimes.java
+++ b/time/src/main/java/io/spine/time/LocalTimes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/time/src/main/java/io/spine/time/ZoneOffsets.java
+++ b/time/src/main/java/io/spine/time/ZoneOffsets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/time/src/main/java/io/spine/time/package-info.java
+++ b/time/src/main/java/io/spine/time/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -40,12 +40,12 @@
 /**
  * Version of this library.
  */
-val time = "1.9.0-SNAPSHOT.6"
+val time = "1.9.0"
 
 /**
  * Versions of the Spine libraries that `time` depends on.
  */
-val base = "1.9.0-SNAPSHOT.6"
+val base = "1.9.0"
 
 project.extra.apply {
     this["versionToPublish"] = time


### PR DESCRIPTION
This changeset releases `time` libraries in version 1.9.0.

Additionally, the year value in copyright headers was updated to 2023.