### PR TITLE
Update docs to the `(when)` option

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.200`
+# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.201`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -984,12 +984,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 26 19:49:54 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 08 17:39:51 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-js:2.0.0-SNAPSHOT.200`
+# Dependencies of `io.spine:spine-time-js:2.0.0-SNAPSHOT.201`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1143,12 +1143,12 @@ This report was generated on **Wed Mar 26 19:49:54 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 26 19:49:54 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 08 17:39:52 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-time-testlib:2.0.0-SNAPSHOT.200`
+# Dependencies of `io.spine.tools:spine-time-testlib:2.0.0-SNAPSHOT.201`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1978,4 +1978,4 @@ This report was generated on **Wed Mar 26 19:49:54 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 26 19:49:54 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 08 17:39:52 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-time</artifactId>
-<version>2.0.0-SNAPSHOT.200</version>
+<version>2.0.0-SNAPSHOT.201</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/time/src/main/proto/spine/time_options.proto
+++ b/time/src/main/proto/spine/time_options.proto
@@ -53,12 +53,19 @@ extend google.protobuf.FieldOptions {
     TimeOption when = 73819;
 }
 
-// The field value is point in time which lies in the future or in the past.
+// Specifies that the field value is a point in time lying either in the future or in the past.
 //
-// Is applicable only to `Timestamp`s and types marked as `Temporal`. See `io.spine.time.Temporal`.
+// Applicable only to `google.protobuf.Timestamp` and types marked as `io.spine.time.Temporal`:
+//
+// 1. `spine.time.ZonedDateTime`.
+// 2. `spine.time.LocalDateTime`.
+// 3. `spine.time.LocalDate`.
+// 4. `spine.time.OffsetDateTime`.
+// 5. `spine.time.YearMonth`.
+//
 // Repeated fields are supported.
 //
-// Example: Using `(when)` option.
+// Example: Using the `(when)` option.
 //
 //     message ScheduleMeeting {
 //         spine.time.ZonedDateTime start = 1 [(when).in = FUTURE];
@@ -66,33 +73,25 @@ extend google.protobuf.FieldOptions {
 //
 message TimeOption {
 
-    // The default error message format string.
-    //
-    // The value of the `${field.time}` placeholder is either "past" or "future" string,
-    // depending on the restriction specified by the `in` field of this option.
-    //
-    option (default_message) = "Point in time must be in the ${field.time}.";
+    // The default error message.
+    option (default_message) = "The field `${parent.type}.${field.path}` must be in the `when.in`."
+        " The passed value: `${field.value}`.";
 
     // Defines a restriction for the timestamp.
     Time in = 1;
 
-    // A user-defined validation error format message.
-    //
-    // Deprecated. Please use `error_msg` instead.
-    //
+    // Deprecated: please use `error_msg` instead.
     string msg_format = 2 [deprecated = true];
 
-    // A user-defined validation error format message.
-    //
     // A user-defined error message.
     //
     // The specified message may include the following placeholders:
     //
-    // 1. `${field.name}` – the field name.
-    // 2. `${field.type}` – the fully qualified name of the field type.
-    // 3. `${field.time}` — is either "past" or "future" string, depending on the restriction
-    //   specified by the `in` field of this option.
-    // 4. `${parent.type}` – the fully qualified name of the field declaring type.
+    // 1. `${field.path}` – the field path.
+    // 2. `${field.value}` - the field value.
+    // 3. `${field.type}` – the fully qualified name of the field type.
+    // 4. `${parent.type}` – the fully qualified name of the validated message.
+    // 5. `${when.in}` – the specified timestamp restriction. It is either "past" or "future".
     //
     string error_msg = 3;
 }

--- a/time/src/main/proto/spine/time_options.proto
+++ b/time/src/main/proto/spine/time_options.proto
@@ -55,13 +55,8 @@ extend google.protobuf.FieldOptions {
 
 // Specifies that the field value is a point in time lying either in the future or in the past.
 //
-// Applicable only to `google.protobuf.Timestamp` and types marked as `io.spine.time.Temporal`:
-//
-// 1. `spine.time.ZonedDateTime`.
-// 2. `spine.time.LocalDateTime`.
-// 3. `spine.time.LocalDate`.
-// 4. `spine.time.OffsetDateTime`.
-// 5. `spine.time.YearMonth`.
+// Applicable to `google.protobuf.Timestamp` and types introduced in the `spine.time` package
+// that describe time-related concepts.
 //
 // Repeated fields are supported.
 //

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For dependencies on Spine modules please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish by extra("2.0.0-SNAPSHOT.200")
+val versionToPublish by extra("2.0.0-SNAPSHOT.201")


### PR DESCRIPTION
This PR brings more consistency with the options declared in `options.proto`.

It updates the option error message template and adds/renames some of the placeholders.