### PR TITLE
Fix publishing of new modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,10 +93,7 @@ plugins {
 }
 
 spinePublishing {
-    modules = setOf(
-        "time",
-        "time-testlib"
-    )
+    modules = productionModules.map { it.name }.toSet() - "time-js"
     destinations = with(PublishingRepos) {
         setOf(
             gitHub("time"),

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.210`
+# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.211`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1006,14 +1006,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 28 21:58:00 WET 2025** using 
+This report was generated on **Wed Oct 29 15:43:04 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.210`
+# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.211`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1849,14 +1849,14 @@ This report was generated on **Tue Oct 28 21:58:00 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 28 21:58:00 WET 2025** using 
+This report was generated on **Wed Oct 29 15:43:04 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-js:2.0.0-SNAPSHOT.210`
+# Dependencies of `io.spine:spine-time-js:2.0.0-SNAPSHOT.211`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2038,14 +2038,14 @@ This report was generated on **Tue Oct 28 21:58:00 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 28 21:57:59 WET 2025** using 
+This report was generated on **Wed Oct 29 15:43:03 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.210`
+# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.211`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2885,14 +2885,14 @@ This report was generated on **Tue Oct 28 21:57:59 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 28 21:58:00 WET 2025** using 
+This report was generated on **Wed Oct 29 15:43:04 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-time-testlib:2.0.0-SNAPSHOT.210`
+# Dependencies of `io.spine.tools:spine-time-testlib:2.0.0-SNAPSHOT.211`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3728,6 +3728,6 @@ This report was generated on **Tue Oct 28 21:58:00 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 28 21:58:00 WET 2025** using 
+This report was generated on **Wed Oct 29 15:43:04 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-time</artifactId>
-<version>2.0.0-SNAPSHOT.210</version>
+<version>2.0.0-SNAPSHOT.211</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For dependencies on Spine modules please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish by extra("2.0.0-SNAPSHOT.210")
+val versionToPublish by extra("2.0.0-SNAPSHOT.211")


### PR DESCRIPTION
This PR updates the build script to include all production modules but `time-js` into publishing.

The previous PR which added new modules did not update the `spinePublishing` block.