### PR TITLE
Change `io.spine.time.testing` to `io.spine.testing.time`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.211`
+# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.220`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1006,14 +1006,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 29 15:43:04 WET 2025** using 
+This report was generated on **Wed Oct 29 16:25:20 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.211`
+# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.220`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1849,14 +1849,14 @@ This report was generated on **Wed Oct 29 15:43:04 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 29 15:43:04 WET 2025** using 
+This report was generated on **Wed Oct 29 16:25:20 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-js:2.0.0-SNAPSHOT.211`
+# Dependencies of `io.spine:spine-time-js:2.0.0-SNAPSHOT.220`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2038,14 +2038,14 @@ This report was generated on **Wed Oct 29 15:43:04 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 29 15:43:03 WET 2025** using 
+This report was generated on **Wed Oct 29 16:25:19 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.211`
+# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.220`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2885,14 +2885,14 @@ This report was generated on **Wed Oct 29 15:43:03 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 29 15:43:04 WET 2025** using 
+This report was generated on **Wed Oct 29 16:25:20 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-time-testlib:2.0.0-SNAPSHOT.211`
+# Dependencies of `io.spine.tools:spine-time-testlib:2.0.0-SNAPSHOT.220`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3728,6 +3728,6 @@ This report was generated on **Wed Oct 29 15:43:04 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 29 15:43:04 WET 2025** using 
+This report was generated on **Wed Oct 29 16:25:20 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-time</artifactId>
-<version>2.0.0-SNAPSHOT.211</version>
+<version>2.0.0-SNAPSHOT.220</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/time-testlib/src/main/java/io/spine/testing/time/BackToTheFuture.java
+++ b/time-testlib/src/main/java/io/spine/testing/time/BackToTheFuture.java
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.testing;
+package io.spine.testing.time;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;

--- a/time-testlib/src/main/java/io/spine/testing/time/FrozenMadHatterParty.java
+++ b/time-testlib/src/main/java/io/spine/testing/time/FrozenMadHatterParty.java
@@ -24,50 +24,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.testing;
+package io.spine.testing.time;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Timestamp;
 import io.spine.base.Time;
 
-import java.time.LocalTime;
-
-import static io.spine.base.Time.currentTime;
-import static io.spine.base.Time.currentTimeZone;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Utility class for working with time-related tests.
+ * The provider of current time, which is always the same.
+ *
+ * <p>Use this {@code Timestamps.Provider} in time-related tests that are
+ * sensitive to bounds of minutes, hours, days, etc.
  */
 @VisibleForTesting
-public final class TimeTests {
+public class FrozenMadHatterParty implements Time.Provider {
+
+    private final Timestamp frozenTime;
 
     /**
-     * Prevents instantiation of this utility class.
+     * Creates a new party with the given time.
      */
-    private TimeTests() {
+    public FrozenMadHatterParty(Timestamp frozenTime) {
+        this.frozenTime = checkNotNull(frozenTime);
     }
 
-    /**
-     * Returns the {@linkplain Time#currentTime() current time} in seconds.
-     *
-     * @return a seconds value
-     */
-    public static long currentTimeSeconds() {
-        var secs = currentTime().getSeconds();
-        return secs;
-    }
-
-    /**
-     * Waits till new day to come, if it's the last day second.
-     *
-     * <p>This method is useful for tests that obtain current date/time values
-     * and need to avoid the day edge for correctness of the test values.
-     */
-    @SuppressWarnings("StatementWithEmptyBody")
-    public static void avoidDayEdge() {
-        var lastDaySecond = LocalTime.MAX.withNano(0);
-        do {
-            // Wait.
-        } while (LocalTime.now(currentTimeZone())
-                          .isAfter(lastDaySecond));
+    /** Returns the value passed to the constructor. */
+    @Override
+    public Timestamp currentTime() {
+        return frozenTime;
     }
 }

--- a/time-testlib/src/main/java/io/spine/testing/time/Future.java
+++ b/time-testlib/src/main/java/io/spine/testing/time/Future.java
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.testing;
+package io.spine.testing.time;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Timestamp;

--- a/time-testlib/src/main/java/io/spine/testing/time/Past.java
+++ b/time-testlib/src/main/java/io/spine/testing/time/Past.java
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.testing;
+package io.spine.testing.time;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Timestamp;

--- a/time-testlib/src/main/java/io/spine/testing/time/TimeTests.java
+++ b/time-testlib/src/main/java/io/spine/testing/time/TimeTests.java
@@ -24,35 +24,50 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.testing;
+package io.spine.testing.time;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.protobuf.Timestamp;
 import io.spine.base.Time;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.time.LocalTime;
+
+import static io.spine.base.Time.currentTime;
+import static io.spine.base.Time.currentTimeZone;
 
 /**
- * The provider of current time, which is always the same.
- *
- * <p>Use this {@code Timestamps.Provider} in time-related tests that are
- * sensitive to bounds of minutes, hours, days, etc.
+ * Utility class for working with time-related tests.
  */
 @VisibleForTesting
-public class FrozenMadHatterParty implements Time.Provider {
-
-    private final Timestamp frozenTime;
+public final class TimeTests {
 
     /**
-     * Creates a new party with the given time.
+     * Prevents instantiation of this utility class.
      */
-    public FrozenMadHatterParty(Timestamp frozenTime) {
-        this.frozenTime = checkNotNull(frozenTime);
+    private TimeTests() {
     }
 
-    /** Returns the value passed to the constructor. */
-    @Override
-    public Timestamp currentTime() {
-        return frozenTime;
+    /**
+     * Returns the {@linkplain Time#currentTime() current time} in seconds.
+     *
+     * @return a seconds value
+     */
+    public static long currentTimeSeconds() {
+        var secs = currentTime().getSeconds();
+        return secs;
+    }
+
+    /**
+     * Waits till new day to come, if it's the last day second.
+     *
+     * <p>This method is useful for tests that obtain current date/time values
+     * and need to avoid the day edge for correctness of the test values.
+     */
+    @SuppressWarnings("StatementWithEmptyBody")
+    public static void avoidDayEdge() {
+        var lastDaySecond = LocalTime.MAX.withNano(0);
+        do {
+            // Wait.
+        } while (LocalTime.now(currentTimeZone())
+                          .isAfter(lastDaySecond));
     }
 }

--- a/time-testlib/src/main/java/io/spine/testing/time/package-info.java
+++ b/time-testlib/src/main/java/io/spine/testing/time/package-info.java
@@ -29,7 +29,7 @@
  */
 @CheckReturnValue
 @NullMarked
-package io.spine.time.testing;
+package io.spine.testing.time;
 
 import com.google.errorprone.annotations.CheckReturnValue;
 

--- a/time-testlib/src/test/java/io/spine/testing/time/BackToTheFutureTest.java
+++ b/time-testlib/src/test/java/io/spine/testing/time/BackToTheFutureTest.java
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.testing;
+package io.spine.testing.time;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/time-testlib/src/test/java/io/spine/testing/time/TimeTestsTests.java
+++ b/time-testlib/src/test/java/io/spine/testing/time/TimeTestsTests.java
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.testing;
+package io.spine.testing.time;
 
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Duration;

--- a/time/src/test/java/io/spine/time/LocalDateTimesTest.java
+++ b/time/src/test/java/io/spine/time/LocalDateTimesTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import static io.spine.base.Time.currentTimeZone;
 import static io.spine.time.Asserts.assertDatesEqual;
 import static io.spine.time.Month.JULY;
-import static io.spine.time.testing.TimeTests.avoidDayEdge;
+import static io.spine.testing.time.TimeTests.avoidDayEdge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/time/src/test/java/io/spine/time/LocalDatesTest.java
+++ b/time/src/test/java/io/spine/time/LocalDatesTest.java
@@ -37,7 +37,7 @@ import java.time.Year;
 import static io.spine.base.Time.currentTimeZone;
 import static io.spine.time.Asserts.assertDatesEqual;
 import static io.spine.time.LocalDates.checkDate;
-import static io.spine.time.testing.TimeTests.avoidDayEdge;
+import static io.spine.testing.time.TimeTests.avoidDayEdge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/time/src/test/java/io/spine/time/YearMonthsTest.java
+++ b/time/src/test/java/io/spine/time/YearMonthsTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.base.Time.currentTimeZone;
-import static io.spine.time.testing.TimeTests.avoidDayEdge;
+import static io.spine.testing.time.TimeTests.avoidDayEdge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayName("`YearMonths` should")

--- a/time/src/test/java/io/spine/time/ZonedDateTimesTest.java
+++ b/time/src/test/java/io/spine/time/ZonedDateTimesTest.java
@@ -35,7 +35,7 @@ import static io.spine.base.Time.currentTimeZone;
 import static io.spine.protobuf.Messages.isNotDefault;
 import static io.spine.time.Asserts.assertDatesEqual;
 import static io.spine.time.ZonedDateTimes.toJavaTime;
-import static io.spine.time.testing.TimeTests.avoidDayEdge;
+import static io.spine.testing.time.TimeTests.avoidDayEdge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For dependencies on Spine modules please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish by extra("2.0.0-SNAPSHOT.211")
+val versionToPublish by extra("2.0.0-SNAPSHOT.220")


### PR DESCRIPTION
This PR adjusts the Time TestLib packages to comply with [our guidelines](https://github.com/SpineEventEngine/documentation/wiki/Packages-and-Maven-artifacts#packages-in-java-and-kotlin-code).