### PR TITLE
Force Jackson for publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@
 import io.spine.dependency.build.Dokka
 import io.spine.dependency.kotlinx.Coroutines
 import io.spine.dependency.lib.Grpc
+import io.spine.dependency.lib.Jackson
 import io.spine.dependency.lib.Kotlin
 import io.spine.dependency.lib.KotlinPoet
 import io.spine.dependency.local.Base
@@ -130,8 +131,13 @@ allprojects {
             exclude(group = "io.spine", module = "spine-validate")
             exclude(group = "io.spine", module = "spine-flogger-api")
             resolutionStrategy {
-                Coroutines.forceArtifacts(project, this@all, this@resolutionStrategy)
-                Grpc.forceArtifacts(project, this@all, this@resolutionStrategy)
+                val cfg = this@all
+                val rs = this@resolutionStrategy
+                Jackson.forceArtifacts(project, cfg, rs)
+                Jackson.DataType.forceArtifacts(project, cfg, rs)
+                Jackson.DataFormat.forceArtifacts(project, cfg, rs)
+                Coroutines.forceArtifacts(project, cfg, rs)
+                Grpc.forceArtifacts(project, cfg, rs)
                 force(
                     Kotlin.bom,
                     KotlinPoet.lib,

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.225`
+# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.226`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1022,14 +1022,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 22 18:19:52 WET 2025** using 
+This report was generated on **Mon Dec 22 19:38:35 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.225`
+# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.226`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1881,14 +1881,14 @@ This report was generated on **Mon Dec 22 18:19:52 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 22 18:19:52 WET 2025** using 
+This report was generated on **Mon Dec 22 19:38:35 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-js:2.0.0-SNAPSHOT.225`
+# Dependencies of `io.spine:spine-time-js:2.0.0-SNAPSHOT.226`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2070,14 +2070,14 @@ This report was generated on **Mon Dec 22 18:19:52 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 22 18:19:51 WET 2025** using 
+This report was generated on **Mon Dec 22 19:38:35 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.225`
+# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.226`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2933,14 +2933,14 @@ This report was generated on **Mon Dec 22 18:19:51 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 22 18:19:52 WET 2025** using 
+This report was generated on **Mon Dec 22 19:38:35 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-time-testlib:2.0.0-SNAPSHOT.225`
+# Dependencies of `io.spine.tools:spine-time-testlib:2.0.0-SNAPSHOT.226`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3792,6 +3792,6 @@ This report was generated on **Mon Dec 22 18:19:52 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 22 18:19:52 WET 2025** using 
+This report was generated on **Mon Dec 22 19:38:35 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-time</artifactId>
-<version>2.0.0-SNAPSHOT.225</version>
+<version>2.0.0-SNAPSHOT.226</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For dependencies on Spine modules please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish by extra("2.0.0-SNAPSHOT.225")
+val versionToPublish by extra("2.0.0-SNAPSHOT.226")


### PR DESCRIPTION
This PR updates the build script forcing Jackson components that are used by Dokka during publishing the documentation. This fixes the issue which prevented [publishing of the docs in the previous PR](https://github.com/SpineEventEngine/time/actions/runs/20440573215/job/58732315517).