### PR TITLE
Rename `io.spine.time.validate` package

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.226`
+# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.230`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1022,14 +1022,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 22 19:38:35 WET 2025** using 
+This report was generated on **Tue Dec 23 17:45:28 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.226`
+# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.230`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1881,14 +1881,14 @@ This report was generated on **Mon Dec 22 19:38:35 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 22 19:38:35 WET 2025** using 
+This report was generated on **Tue Dec 23 17:45:28 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-js:2.0.0-SNAPSHOT.226`
+# Dependencies of `io.spine:spine-time-js:2.0.0-SNAPSHOT.230`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2070,14 +2070,14 @@ This report was generated on **Mon Dec 22 19:38:35 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 22 19:38:35 WET 2025** using 
+This report was generated on **Tue Dec 23 17:45:27 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.226`
+# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.230`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2933,14 +2933,14 @@ This report was generated on **Mon Dec 22 19:38:35 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 22 19:38:35 WET 2025** using 
+This report was generated on **Tue Dec 23 17:45:28 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-time-testlib:2.0.0-SNAPSHOT.226`
+# Dependencies of `io.spine.tools:spine-time-testlib:2.0.0-SNAPSHOT.230`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3792,6 +3792,6 @@ This report was generated on **Mon Dec 22 19:38:35 WET 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 22 19:38:35 WET 2025** using 
+This report was generated on **Tue Dec 23 17:45:28 WET 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-time</artifactId>
-<version>2.0.0-SNAPSHOT.226</version>
+<version>2.0.0-SNAPSHOT.230</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/time/src/main/java/io/spine/time/validation/TimeOptionsProvider.java
+++ b/time/src/main/java/io/spine/time/validation/TimeOptionsProvider.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,10 +24,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@CheckReturnValue
-@NullMarked
-package io.spine.time.validate.given;
+package io.spine.time.validation;
 
-import com.google.errorprone.annotations.CheckReturnValue;
+import com.google.auto.service.AutoService;
+import com.google.protobuf.ExtensionRegistry;
+import io.spine.option.OptionsProvider;
 
-import org.jspecify.annotations.NullMarked;
+/**
+ * Registers time-related proto options introduced by this library.
+ */
+@AutoService(OptionsProvider.class)
+public class TimeOptionsProvider implements OptionsProvider {
+
+    @Override
+    public void registerIn(ExtensionRegistry registry) {
+        TimeOptionsProto.registerAllExtensions(registry);
+    }
+}

--- a/time/src/main/java/io/spine/time/validation/When.java
+++ b/time/src/main/java/io/spine/time/validation/When.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,14 +24,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+package io.spine.time.validation;
+
+import com.google.protobuf.Timestamp;
+import io.spine.code.proto.FieldContext;
+import io.spine.validation.Constraint;
+import io.spine.validation.option.FieldValidatingOption;
+
 /**
- * This package defines validation constraints for time-bearing types.
+ * A validating option that specified the point in time which
+ * a {@link Timestamp} field value has.
  */
+final class When extends FieldValidatingOption<TimeOption> {
 
-@CheckReturnValue
-@NullMarked
-package io.spine.time.validate;
+    private When() {
+        super(TimeOptionsProto.when);
+    }
 
-import com.google.errorprone.annotations.CheckReturnValue;
+    /** Creates a new instance of this option. */
+    public static When create() {
+        return new When();
+    }
 
-import org.jspecify.annotations.NullMarked;
+    @Override
+    public Constraint constraintFor(FieldContext value) {
+        return new WhenConstraint(optionValue(value), value.targetDeclaration());
+    }
+}

--- a/time/src/main/java/io/spine/time/validation/WhenConstraint.java
+++ b/time/src/main/java/io/spine/time/validation/WhenConstraint.java
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.validate;
+package io.spine.time.validation;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Message;
@@ -33,8 +33,6 @@ import io.spine.code.proto.FieldContext;
 import io.spine.code.proto.FieldDeclaration;
 import io.spine.time.Temporal;
 import io.spine.time.Temporals;
-import io.spine.time.validation.Time;
-import io.spine.time.validation.TimeOption;
 import io.spine.validation.ConstraintViolation;
 import io.spine.validation.CustomConstraint;
 import io.spine.validation.FieldValue;

--- a/time/src/main/java/io/spine/time/validation/WhenFactory.kt
+++ b/time/src/main/java/io/spine/time/validation/WhenFactory.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,21 +24,32 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.validate;
+package io.spine.time.validation
 
-import com.google.auto.service.AutoService;
-import com.google.protobuf.ExtensionRegistry;
-import io.spine.option.OptionsProvider;
-import io.spine.time.validation.TimeOptionsProto;
+import com.google.auto.service.AutoService
+import com.google.common.collect.ImmutableSet
+import com.google.errorprone.annotations.Immutable
+import io.spine.annotation.Internal
+import io.spine.validation.option.FieldValidatingOption
+import io.spine.validation.option.ValidatingOptionFactory
 
 /**
- * Registers time-related proto options introduced by this library.
+ * An implementation of [ValidatingOptionFactory] which adds the [When] option
+ * for message fields.
  */
-@AutoService(OptionsProvider.class)
-public class TimeOptionsProvider implements OptionsProvider {
+@AutoService(ValidatingOptionFactory::class)
+@Internal
+@Immutable
+public class WhenFactory : ValidatingOptionFactory {
 
-    @Override
-    public void registerIn(ExtensionRegistry registry) {
-        TimeOptionsProto.registerAllExtensions(registry);
+    override fun forMessage(): Set<FieldValidatingOption<*>> {
+        return typeOptions
+    }
+
+    private companion object {
+
+        private val typeOptions by lazy {
+            ImmutableSet.of<FieldValidatingOption<*>>(When.create())
+        }
     }
 }

--- a/time/src/main/java/io/spine/time/validation/package-info.java
+++ b/time/src/main/java/io/spine/time/validation/package-info.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,32 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.validate;
-
-import com.google.protobuf.Timestamp;
-import io.spine.code.proto.FieldContext;
-import io.spine.time.validation.TimeOption;
-import io.spine.time.validation.TimeOptionsProto;
-import io.spine.validation.Constraint;
-import io.spine.validation.option.FieldValidatingOption;
-
 /**
- * A validating option that specified the point in time which
- * a {@link Timestamp} field value has.
+ * This package defines validation constraints for time-bearing types.
  */
-final class When extends FieldValidatingOption<TimeOption> {
 
-    private When() {
-        super(TimeOptionsProto.when);
-    }
+@CheckReturnValue
+@NullMarked
+package io.spine.time.validation;
 
-    /** Creates a new instance of this option. */
-    public static When create() {
-        return new When();
-    }
+import com.google.errorprone.annotations.CheckReturnValue;
 
-    @Override
-    public Constraint constraintFor(FieldContext value) {
-        return new WhenConstraint(optionValue(value), value.targetDeclaration());
-    }
-}
+import org.jspecify.annotations.NullMarked;

--- a/time/src/test/java/io/spine/time/validation/WhenFactoryTest.java
+++ b/time/src/test/java/io/spine/time/validation/WhenFactoryTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.validate;
+package io.spine.time.validation;
 
 import com.google.common.collect.Iterables;
 import io.spine.validation.option.ValidatingOptionFactory;

--- a/time/src/test/java/io/spine/time/validation/WhenTest.java
+++ b/time/src/test/java/io/spine/time/validation/WhenTest.java
@@ -24,9 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.validate;
+package io.spine.time.validation;
 
 import io.spine.base.Time;
+import io.spine.time.validation.given.AlwaysValidTime;
+import io.spine.time.validation.given.TimeInFutureFieldValue;
+import io.spine.time.validation.given.TimeInPastFieldValue;
+import io.spine.time.validation.given.TimeWithDefaultErrorMessage;
+import io.spine.time.validation.given.TimeWithoutOptsFieldValue;
 import io.spine.validation.ConstraintViolation;
 import io.spine.validation.TemplateString;
 import io.spine.validation.TemplateStrings;
@@ -38,13 +43,13 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.string.Strings.count;
-import static io.spine.time.validate.given.WhenTestEnv.FIFTY_NANOSECONDS;
-import static io.spine.time.validate.given.WhenTestEnv.ZERO_NANOSECONDS;
-import static io.spine.time.validate.given.WhenTestEnv.currentTimeWithNanos;
-import static io.spine.time.validate.given.WhenTestEnv.freezeTime;
-import static io.spine.time.validate.given.WhenTestEnv.future;
-import static io.spine.time.validate.given.WhenTestEnv.past;
-import static io.spine.time.validate.given.WhenTestEnv.timeWithNanos;
+import static io.spine.time.validation.given.WhenTestEnv.FIFTY_NANOSECONDS;
+import static io.spine.time.validation.given.WhenTestEnv.ZERO_NANOSECONDS;
+import static io.spine.time.validation.given.WhenTestEnv.currentTimeWithNanos;
+import static io.spine.time.validation.given.WhenTestEnv.freezeTime;
+import static io.spine.time.validation.given.WhenTestEnv.future;
+import static io.spine.time.validation.given.WhenTestEnv.past;
+import static io.spine.time.validation.given.WhenTestEnv.timeWithNanos;
 
 @DisplayName("`(when)` option should")
 class WhenTest {

--- a/time/src/test/java/io/spine/time/validation/given/WhenTestEnv.java
+++ b/time/src/test/java/io/spine/time/validation/given/WhenTestEnv.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.validate.given;
+package io.spine.time.validation.given;
 
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;

--- a/time/src/test/java/io/spine/time/validation/given/package-info.java
+++ b/time/src/test/java/io/spine/time/validation/given/package-info.java
@@ -24,32 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.time.validate
+@CheckReturnValue
+@NullMarked
+package io.spine.time.validation.given;
 
-import com.google.auto.service.AutoService
-import com.google.common.collect.ImmutableSet
-import com.google.errorprone.annotations.Immutable
-import io.spine.annotation.Internal
-import io.spine.validation.option.FieldValidatingOption
-import io.spine.validation.option.ValidatingOptionFactory
+import com.google.errorprone.annotations.CheckReturnValue;
 
-/**
- * An implementation of [ValidatingOptionFactory] which adds the [When] option
- * for message fields.
- */
-@AutoService(ValidatingOptionFactory::class)
-@Internal
-@Immutable
-public class WhenFactory : ValidatingOptionFactory {
-
-    override fun forMessage(): Set<FieldValidatingOption<*>> {
-        return typeOptions
-    }
-
-    private companion object {
-
-        private val typeOptions by lazy {
-            ImmutableSet.of<FieldValidatingOption<*>>(When.create())
-        }
-    }
-}
+import org.jspecify.annotations.NullMarked;

--- a/time/src/test/proto/spine/time/validation/messages.proto
+++ b/time/src/test/proto/spine/time/validation/messages.proto
@@ -26,13 +26,13 @@
 
 syntax = "proto3";
 
-package spine.time.validate;
+package spine.time.validation;
 
 import "spine/options.proto";
 import "spine/time_options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package = "io.spine.time.validate";
+option java_package = "io.spine.time.validation.given";
 option java_outer_classname = "MessagesProto";
 option java_multiple_files = true;
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For dependencies on Spine modules please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish by extra("2.0.0-SNAPSHOT.226")
+val versionToPublish by extra("2.0.0-SNAPSHOT.230")


### PR DESCRIPTION
This PR renames the `io.spine.time.validate` package to `validation`.