### PR TITLE
Support map values in `(when)`

### DIFF
--- a/.agents/_TOC.md
+++ b/.agents/_TOC.md
@@ -13,4 +13,4 @@
 11. [Advanced safety rules](advanced-safety-rules.md)
 12. [Refactoring guidelines](refactoring-guidelines.md)
 13. [Common tasks](common-tasks.md)
-14. [Java to Kotlin conversion](java-kotlin-conversion.md)
+14. [Java to Kotlin conversion](skills/java-to-kotlin/SKILL.md)

--- a/.agents/quick-reference-card.md
+++ b/.agents/quick-reference-card.md
@@ -3,7 +3,6 @@
 ```
 🔑 Key Information:
 - Kotlin/Java project with CQRS architecture
-- Use ChatGPT for documentation, Codex for code generation, GPT-4o for complex analysis
 - Follow coding guidelines in Spine Event Engine docs
 - Always include tests with code changes
 - Version bump required for all PRs

--- a/.agents/skills/java-to-kotlin/SKILL.md
+++ b/.agents/skills/java-to-kotlin/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: java-to-kotlin
+description: >
+  Convert Java code to Kotlin, including Java API comments from Javadoc to KDoc.
+  Use when asked to migrate Java files, classes, methods, nullability semantics,
+  or common Java patterns into idiomatic Kotlin while preserving behavior.
+---
+
 # 🪄 Converting Java code to Kotlin
 
 * Java code API comments are Javadoc format.

--- a/.agents/skills/java-to-kotlin/agents/openai.yaml
+++ b/.agents/skills/java-to-kotlin/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Java to Kotlin"
+  short_description: "Convert Java code to idiomatic Kotlin"
+  default_prompt: "Use $java-to-kotlin to convert Java code to Kotlin while preserving behavior, nullability, and API documentation wording."

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -1,10 +1,9 @@
-name: Build under Ubuntu
+name: Build on Ubuntu
 
 on: push
 
 jobs:
   build:
-    name: Build under Ubuntu
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -1,10 +1,9 @@
-name: Build under Windows
+name: Build on Windows
 
 on: pull_request
 
 jobs:
   build:
-    name: Build under Windows
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/ensure-reports-updated.yml
+++ b/.github/workflows/ensure-reports-updated.yml
@@ -8,8 +8,7 @@ on:
       - '**'
 
 jobs:
-  build:
-    name: Ensure license reports updated
+  check:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   validation:
-    name: Gradle Wrapper Validation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code

--- a/.github/workflows/increment-guard.yml
+++ b/.github/workflows/increment-guard.yml
@@ -9,8 +9,7 @@ on:
       - '**'
 
 jobs:
-  build:
-    name: Check version increment
+  check:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/remove-obsolete-artifacts-from-packages.yaml
+++ b/.github/workflows/remove-obsolete-artifacts-from-packages.yaml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   retrieve-package-names:
-    name: Retrieve the package names published from this repository
+    name: Retrieve package names
     runs-on: ubuntu-latest
     outputs:
       package-names: ${{ steps.request-package-names.outputs.package-names }}
@@ -54,7 +54,7 @@ jobs:
           echo "package-names=$(<./package-names.json)" >> $GITHUB_OUTPUT
 
   delete-obsolete-artifacts:
-    name: Remove obsolete artifacts published from this repository to GitHub Packages
+    name: Delete obsolete artifacts
     needs: retrieve-package-names
     runs-on: ubuntu-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@
 
 # Internal tool directories.
 .fleet/
+.junie/memory/
 
 # Kotlin temp directories.
 **/.kotlin/

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -10,7 +10,7 @@ Also follow the Junie-specific rules described below.
 
 ## Junie Assistance Tips
 
-When working with Junie AI on the Spine Tool-Base project:
+When working with Junie AI on the Spine family of projects:
 
 1. **Project Navigation**: Use `search_project` to find relevant files and code segments.
 2. **Code Understanding**: Request file structure with `get_file_structure` before editing.

--- a/.junie/skills
+++ b/.junie/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -137,8 +137,6 @@ val koverVersion = "0.9.1"
 /**
  * The version of the Shadow Plugin.
  *
- * `7.1.2` is the last version compatible with Gradle 7.x. Newer versions require Gradle v8.x.
- *
  * @see <a href="https://github.com/GradleUp/shadow">Shadow Plugin releases</a>
  */
 val shadowVersion = "9.4.1"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Dokka.kt
@@ -26,7 +26,6 @@
 
 package io.spine.dependency.build
 
-import io.spine.dependency.build.Dokka.GradlePlugin.id
 import io.spine.dependency.local.Spine
 
 // https://github.com/Kotlin/dokka

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,7 +46,7 @@ object CoreJvmCompiler {
     /**
      * The version used to in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.062"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.063"
 
     /**
      * The version to be used for integration tests.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -40,7 +40,7 @@ import io.spine.dependency.Dependency
 )
 object Time : Dependency() {
     override val group = Spine.group
-    override val version = "2.0.0-SNAPSHOT.235"
+    override val version = "2.0.0-SNAPSHOT.236"
     private const val infix = "spine-time"
 
     fun lib(version: String): String = "$group:$infix:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.413"
+    const val version = "2.0.0-SNAPSHOT.414"
 
     /**
      * The last version of Validation compatible with ProtoData.

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:time-gradle-plugin:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine.tools:time-gradle-plugin:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -1059,14 +1059,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using 
+This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:time-testlib:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine.tools:time-testlib:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1869,14 +1869,14 @@ This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using 
+This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2833,14 +2833,14 @@ This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using 
+This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3643,14 +3643,14 @@ This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using 
+This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4461,14 +4461,14 @@ This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using 
+This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:time-validation:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine.tools:time-validation:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -5590,14 +5590,14 @@ This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using 
+This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-validation-tests:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-validation-tests:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -6683,6 +6683,6 @@ This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 28 13:46:33 WEST 2026** using 
+This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1059,7 +1059,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
+This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1869,7 +1869,7 @@ This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
+This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2833,7 +2833,7 @@ This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
+This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3643,7 +3643,7 @@ This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
+This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4461,7 +4461,7 @@ This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
+This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5590,7 +5590,7 @@ This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
+This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6683,6 +6683,6 @@ This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 20:23:43 WEST 2026** using 
+This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1059,7 +1059,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
+This report was generated on **Fri May 01 17:48:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1869,7 +1869,7 @@ This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
+This report was generated on **Fri May 01 17:48:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2833,7 +2833,7 @@ This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
+This report was generated on **Fri May 01 17:48:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3643,7 +3643,7 @@ This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
+This report was generated on **Fri May 01 17:48:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4461,7 +4461,7 @@ This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
+This report was generated on **Fri May 01 17:48:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5590,7 +5590,7 @@ This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
+This report was generated on **Fri May 01 17:48:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6683,6 +6683,6 @@ This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 30 21:13:52 WEST 2026** using 
+This report was generated on **Fri May 01 17:48:31 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-time</artifactId>
-<version>2.0.0-SNAPSHOT.236</version>
+<version>2.0.0-SNAPSHOT.237</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -55,8 +55,14 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
+    <artifactId>spine-time</artifactId>
+    <version>2.0.0-SNAPSHOT.236</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine</groupId>
     <artifactId>spine-validation-jvm-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.413</version>
+    <version>2.0.0-SNAPSHOT.414</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -239,7 +245,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>core-jvm-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.062</version>
+    <version>2.0.0-SNAPSHOT.063</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -253,8 +259,13 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
+    <artifactId>time-validation</artifactId>
+    <version>2.0.0-SNAPSHOT.236</version>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
     <artifactId>validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.413</version>
+    <version>2.0.0-SNAPSHOT.414</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/Fixtures.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/Fixtures.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.time.validation.java
+
+import com.google.protobuf.Timestamp
+import com.google.protobuf.util.Durations.fromMillis
+import com.google.protobuf.util.Timestamps
+import io.spine.time.LocalDateTimes
+import io.spine.time.LocalDateTime
+import java.time.Instant
+import java.time.LocalDateTime.ofInstant
+import java.time.ZoneOffset.UTC
+
+/**
+ * Five hundred milliseconds.
+ *
+ * To shift the time into the past or future, we add or subtract a difference of this amount.
+ *
+ * There are two reasons for choosing 500 milliseconds:
+ *
+ * 1. The generated code uses `io.spine.base.Time.currentTime()` to get the current timestamp
+ *    for comparison. In turn, this method relies on `io.spine.base.Time.SystemTimeProvider`
+ *    by default, which has millisecond precision.
+ * 2. Adding too small amount of time to make the stamp denote "future" might be unreliable.
+ *    As it could catch up `now` by the time `Time.currentTime()` is invoked.
+ */
+private const val HALF_OF_SECOND: Long = 500
+
+internal object TemporalFixtures {
+
+    fun pastTime(): LocalDateTime {
+        val current = Instant.now() // It is a UTC stamp.
+        return LocalDateTimes.of(ofInstant(current.minusMillis(HALF_OF_SECOND), UTC))
+    }
+
+    fun futureTime(): LocalDateTime {
+        val current = Instant.now() // It is a UTC stamp.
+        return LocalDateTimes.of(ofInstant(current.plusMillis(HALF_OF_SECOND), UTC))
+    }
+}
+
+internal object TimestampFixtures {
+
+    fun pastTime(): Timestamp =
+        Timestamps.subtract(Timestamps.now(), fromMillis(HALF_OF_SECOND))
+
+    fun futureTime(): Timestamp =
+        Timestamps.add(Timestamps.now(), fromMillis(HALF_OF_SECOND))
+}

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/ProtoTimestampWhenMapSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/ProtoTimestampWhenMapSpec.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.time.validation.java
+
+import com.google.protobuf.Duration
+import com.google.protobuf.Timestamp
+import com.google.protobuf.util.Durations.fromMillis
+import com.google.protobuf.util.Timestamps
+import io.spine.test.tools.validate.anyProtoTimestampMap
+import io.spine.test.tools.validate.futureProtoTimestampMap
+import io.spine.test.tools.validate.pastProtoTimestampMap
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("If used with a map of Protobuf `Timestamp` values, `(when)` constraint should")
+internal class ProtoTimestampWhenMapSpec {
+
+    @Nested inner class
+    `when given a map with timestamps denoting` {
+
+        @Nested inner class
+        `only the past` {
+
+            private val severalPastTimes = mapOf("a" to pastTime(), "b" to pastTime())
+
+            @Test
+            fun `throw, if restricted to be in future`() = assertValidationFails {
+                futureProtoTimestampMap {
+                    value.putAll(severalPastTimes)
+                }
+            }
+
+            @Test
+            fun `pass, if restricted to be in past`() = assertValidationPasses {
+                pastProtoTimestampMap {
+                    value.putAll(severalPastTimes)
+                }
+            }
+
+            @Test
+            fun `pass, if not restricted at all`() = assertValidationPasses {
+                anyProtoTimestampMap {
+                    value.putAll(severalPastTimes)
+                }
+            }
+        }
+
+        @Nested inner class
+        `only the future` {
+
+            private val severalFutureTimes = mapOf("a" to futureTime(), "b" to futureTime())
+
+            @Test
+            fun `throw, if restricted to be in past`() = assertValidationFails {
+                pastProtoTimestampMap {
+                    value.putAll(severalFutureTimes)
+                }
+            }
+
+            @Test
+            fun `pass, if restricted to be in future`() = assertValidationPasses {
+                futureProtoTimestampMap {
+                    value.putAll(severalFutureTimes)
+                }
+            }
+
+            @Test
+            fun `pass, if not restricted at all`() = assertValidationPasses {
+                anyProtoTimestampMap {
+                    value.putAll(severalFutureTimes)
+                }
+            }
+        }
+
+        @Nested inner class
+        `a mix of past and future` {
+
+            private val mixedTimes = mapOf("a" to futureTime(), "b" to pastTime())
+
+            @Test
+            fun `throw, if restricted to be in future`() = assertValidationFails {
+                futureProtoTimestampMap {
+                    value.putAll(mixedTimes)
+                }
+            }
+
+            @Test
+            fun `throw, if restricted to be in past`() = assertValidationFails {
+                pastProtoTimestampMap {
+                    value.putAll(mixedTimes)
+                }
+            }
+
+            @Test
+            fun `pass, if not restricted at all`() = assertValidationPasses {
+                anyProtoTimestampMap {
+                    value.putAll(mixedTimes)
+                }
+            }
+        }
+    }
+}
+
+private fun pastTime(): Timestamp {
+    val current = Timestamps.now()
+    return Timestamps.subtract(current, HALF_OF_SECOND)
+}
+
+private fun futureTime(): Timestamp {
+    val current = Timestamps.now()
+    return Timestamps.add(current, HALF_OF_SECOND)
+}
+
+private val HALF_OF_SECOND: Duration = fromMillis(500)

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/ProtoTimestampWhenMapSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/ProtoTimestampWhenMapSpec.kt
@@ -26,13 +26,11 @@
 
 package io.spine.tools.time.validation.java
 
-import com.google.protobuf.Duration
-import com.google.protobuf.Timestamp
-import com.google.protobuf.util.Durations.fromMillis
-import com.google.protobuf.util.Timestamps
 import io.spine.test.tools.validate.anyProtoTimestampMap
 import io.spine.test.tools.validate.futureProtoTimestampMap
 import io.spine.test.tools.validate.pastProtoTimestampMap
+import io.spine.tools.time.validation.java.TimestampFixtures.futureTime
+import io.spine.tools.time.validation.java.TimestampFixtures.pastTime
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -125,15 +123,3 @@ internal class ProtoTimestampWhenMapSpec {
         }
     }
 }
-
-private fun pastTime(): Timestamp {
-    val current = Timestamps.now()
-    return Timestamps.subtract(current, HALF_OF_SECOND)
-}
-
-private fun futureTime(): Timestamp {
-    val current = Timestamps.now()
-    return Timestamps.add(current, HALF_OF_SECOND)
-}
-
-private val HALF_OF_SECOND: Duration = fromMillis(500)

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/ProtoTimestampWhenSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/ProtoTimestampWhenSpec.kt
@@ -26,16 +26,14 @@
 
 package io.spine.tools.time.validation.java
 
-import com.google.protobuf.Duration
-import com.google.protobuf.Timestamp
-import com.google.protobuf.util.Durations.fromMillis
-import com.google.protobuf.util.Timestamps
 import io.spine.test.tools.validate.anyProtoTimestamp
 import io.spine.test.tools.validate.anyProtoTimestamps
 import io.spine.test.tools.validate.futureProtoTimestamp
 import io.spine.test.tools.validate.futureProtoTimestamps
 import io.spine.test.tools.validate.pastProtoTimestamp
 import io.spine.test.tools.validate.pastProtoTimestamps
+import io.spine.tools.time.validation.java.TimestampFixtures.futureTime
+import io.spine.tools.time.validation.java.TimestampFixtures.pastTime
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -209,30 +207,3 @@ internal class ProtoTimestampWhenSpec {
         }
     }
 }
-
-private fun pastTime(): Timestamp {
-    val current = Timestamps.now()
-    val past = Timestamps.subtract(current, HALF_OF_SECONDS)
-    return past
-}
-
-private fun futureTime(): Timestamp {
-    val current = Timestamps.now()
-    val future = Timestamps.add(current, HALF_OF_SECONDS)
-    return future
-}
-
-/**
- * Protobuf [Duration] of five hundred milliseconds.
- *
- * To shift the time into the past or future, we add or subtract a difference of this amount.
- *
- * There are two reasons for choosing 500 milliseconds:
- *
- * 1. The generated code uses `io.spine.base.Time.currentTime()` to get the current timestamp
- *    for comparison. In turn, this method relies on `io.spine.base.Time.SystemTimeProvider`
- *    by default, which has millisecond precision.
- * 2. Adding too small amount of time to make the stamp denote "future" might be unreliable.
- *    As it could catch up `now` by the time `Time.currentTime()` is invoked.
- */
-private val HALF_OF_SECONDS: Duration = fromMillis(500)

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/SpineTemporalWhenMapSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/SpineTemporalWhenMapSpec.kt
@@ -29,14 +29,11 @@ package io.spine.tools.time.validation.java
 import io.spine.test.tools.validate.anySpineTemporalMap
 import io.spine.test.tools.validate.futureSpineTemporalMap
 import io.spine.test.tools.validate.pastSpineTemporalMap
-import io.spine.time.LocalDateTimes
-import java.time.Instant
-import java.time.LocalDateTime.ofInstant
-import java.time.ZoneOffset.UTC
+import io.spine.tools.time.validation.java.TemporalFixtures.futureTime
+import io.spine.tools.time.validation.java.TemporalFixtures.pastTime
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import io.spine.time.LocalDateTime as SpineTimeLocalDateTime
 
 @DisplayName("If used with a map of Spine `Temporal` values, `(when)` constraint should")
 internal class SpineTemporalWhenMapSpec {
@@ -126,15 +123,3 @@ internal class SpineTemporalWhenMapSpec {
         }
     }
 }
-
-private fun pastTime(): SpineTimeLocalDateTime {
-    val current = Instant.now()
-    return LocalDateTimes.of(ofInstant(current.minusMillis(HALF_OF_SECOND), UTC))
-}
-
-private fun futureTime(): SpineTimeLocalDateTime {
-    val current = Instant.now()
-    return LocalDateTimes.of(ofInstant(current.plusMillis(HALF_OF_SECOND), UTC))
-}
-
-private const val HALF_OF_SECOND: Long = 500

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/SpineTemporalWhenMapSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/SpineTemporalWhenMapSpec.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.time.validation.java
+
+import io.spine.test.tools.validate.anySpineTemporalMap
+import io.spine.test.tools.validate.futureSpineTemporalMap
+import io.spine.test.tools.validate.pastSpineTemporalMap
+import io.spine.time.LocalDateTimes
+import java.time.Instant
+import java.time.LocalDateTime.ofInstant
+import java.time.ZoneOffset.UTC
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import io.spine.time.LocalDateTime as SpineTimeLocalDateTime
+
+@DisplayName("If used with a map of Spine `Temporal` values, `(when)` constraint should")
+internal class SpineTemporalWhenMapSpec {
+
+    @Nested inner class
+    `when given a map with temporals denoting` {
+
+        @Nested inner class
+        `only the past` {
+
+            private val severalPastTimes = mapOf("a" to pastTime(), "b" to pastTime())
+
+            @Test
+            fun `throw, if restricted to be in future`() = assertValidationFails {
+                futureSpineTemporalMap {
+                    value.putAll(severalPastTimes)
+                }
+            }
+
+            @Test
+            fun `pass, if restricted to be in past`() = assertValidationPasses {
+                pastSpineTemporalMap {
+                    value.putAll(severalPastTimes)
+                }
+            }
+
+            @Test
+            fun `pass, if not restricted at all`() = assertValidationPasses {
+                anySpineTemporalMap {
+                    value.putAll(severalPastTimes)
+                }
+            }
+        }
+
+        @Nested inner class
+        `only the future` {
+
+            private val severalFutureTimes = mapOf("a" to futureTime(), "b" to futureTime())
+
+            @Test
+            fun `throw, if restricted to be in past`() = assertValidationFails {
+                pastSpineTemporalMap {
+                    value.putAll(severalFutureTimes)
+                }
+            }
+
+            @Test
+            fun `pass, if restricted to be in future`() = assertValidationPasses {
+                futureSpineTemporalMap {
+                    value.putAll(severalFutureTimes)
+                }
+            }
+
+            @Test
+            fun `pass, if not restricted at all`() = assertValidationPasses {
+                anySpineTemporalMap {
+                    value.putAll(severalFutureTimes)
+                }
+            }
+        }
+
+        @Nested inner class
+        `a mix of past and future` {
+
+            private val mixedTimes = mapOf("a" to futureTime(), "b" to pastTime())
+
+            @Test
+            fun `throw, if restricted to be in future`() = assertValidationFails {
+                futureSpineTemporalMap {
+                    value.putAll(mixedTimes)
+                }
+            }
+
+            @Test
+            fun `throw, if restricted to be in past`() = assertValidationFails {
+                pastSpineTemporalMap {
+                    value.putAll(mixedTimes)
+                }
+            }
+
+            @Test
+            fun `pass, if not restricted at all`() = assertValidationPasses {
+                anySpineTemporalMap {
+                    value.putAll(mixedTimes)
+                }
+            }
+        }
+    }
+}
+
+private fun pastTime(): SpineTimeLocalDateTime {
+    val current = Instant.now()
+    return LocalDateTimes.of(ofInstant(current.minusMillis(HALF_OF_SECOND), UTC))
+}
+
+private fun futureTime(): SpineTimeLocalDateTime {
+    val current = Instant.now()
+    return LocalDateTimes.of(ofInstant(current.plusMillis(HALF_OF_SECOND), UTC))
+}
+
+private const val HALF_OF_SECOND: Long = 500

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/SpineTemporalWhenSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/SpineTemporalWhenSpec.kt
@@ -32,14 +32,11 @@ import io.spine.test.tools.validate.futureSpineTemporal
 import io.spine.test.tools.validate.futureSpineTemporals
 import io.spine.test.tools.validate.pastSpineTemporal
 import io.spine.test.tools.validate.pastSpineTemporals
-import io.spine.time.LocalDateTimes
-import java.time.Instant
-import java.time.LocalDateTime.ofInstant
-import java.time.ZoneOffset.UTC
+import io.spine.tools.time.validation.java.TemporalFixtures.futureTime
+import io.spine.tools.time.validation.java.TemporalFixtures.pastTime
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import io.spine.time.LocalDateTime as SpineTimeLocalDateTime
 
 @DisplayName("If used with Spine `Temporal`, `(when)` constraint should")
 internal class SpineTemporalWhenSpec {
@@ -210,30 +207,3 @@ internal class SpineTemporalWhenSpec {
         }
     }
 }
-
-private fun pastTime(): SpineTimeLocalDateTime {
-    val current = Instant.now() // It is a UTC stamp.
-    val past = current.minusMillis(HALF_OF_SECOND)
-    return LocalDateTimes.of(ofInstant(past, UTC))
-}
-
-private fun futureTime(): SpineTimeLocalDateTime {
-    val current = Instant.now() // It is a UTC stamp.
-    val past = current.plusMillis(HALF_OF_SECOND)
-    return LocalDateTimes.of(ofInstant(past, UTC))
-}
-
-/**
- * Five hundred milliseconds.
- *
- * To shift the time into the past or future, we add or subtract a difference of this amount.
- *
- * There are two reasons for choosing 500 milliseconds:
- *
- * 1. The generated code uses `io.spine.base.Time.currentTime()` to get the current timestamp
- *    for comparison. In turn, this method relies on `io.spine.base.Time.SystemTimeProvider`
- *    by default, which has millisecond precision.
- * 2. Adding too small amount of time to make the stamp denote "future" might be unreliable.
- *    As it could catch up `now` by the time `Time.currentTime()` is invoked.
- */
-private const val HALF_OF_SECOND: Long = 500

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/TemporalRepeatedWhenSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/TemporalRepeatedWhenSpec.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.time.validation.java
+
+import io.spine.test.tools.validate.anySpineTemporals
+import io.spine.test.tools.validate.futureSpineTemporals
+import io.spine.test.tools.validate.pastSpineTemporals
+import io.spine.tools.time.validation.java.TemporalFixtures.futureTime
+import io.spine.tools.time.validation.java.TemporalFixtures.pastTime
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("If used with repeated `Temporal`, `(when)` constraint should")
+internal class TemporalRepeatedWhenSpec {
+
+    @Nested inner class
+    `denoting only the past` {
+
+        private val severalPastTimes = listOf(pastTime(), pastTime(), pastTime())
+
+        @Test
+        fun `throw, if restricted to be in future`() = assertValidationFails {
+            futureSpineTemporals {
+                value.addAll(severalPastTimes)
+            }
+        }
+
+        @Test
+        fun `pass, if restricted to be in past`() = assertValidationPasses {
+            pastSpineTemporals {
+                value.addAll(severalPastTimes)
+            }
+        }
+
+        @Test
+        fun `pass, if not restricted at all`() = assertValidationPasses {
+            anySpineTemporals {
+                value.addAll(severalPastTimes)
+            }
+        }
+    }
+
+    @Nested inner class
+    `denoting only the future` {
+
+        private val severalFutureTimes = listOf(futureTime(), futureTime(), futureTime())
+
+        @Test
+        fun `throw, if restricted to be in past`() = assertValidationFails {
+            pastSpineTemporals {
+                value.addAll(severalFutureTimes)
+            }
+        }
+
+        @Test
+        fun `pass, if restricted to be in future`() = assertValidationPasses {
+            futureSpineTemporals {
+                value.addAll(severalFutureTimes)
+            }
+        }
+
+        @Test
+        fun `pass, if not restricted at all`() = assertValidationPasses {
+            anySpineTemporals {
+                value.addAll(severalFutureTimes)
+            }
+        }
+    }
+
+    @Nested inner class
+    `with a single past time within the future times` {
+
+        private val severalFutureAndPast = listOf(futureTime(), pastTime(), futureTime())
+
+        @Test
+        fun `throw, if restricted to be in future`() = assertValidationFails {
+            futureSpineTemporals {
+                value.addAll(severalFutureAndPast)
+            }
+        }
+
+        @Test
+        fun `throw, if restricted to be in past`() = assertValidationFails {
+            pastSpineTemporals {
+                value.addAll(severalFutureAndPast)
+            }
+        }
+
+        @Test
+        fun `pass, if not restricted at all`() = assertValidationPasses {
+            anySpineTemporals {
+                value.addAll(severalFutureAndPast)
+            }
+        }
+    }
+
+    @Nested inner class
+    `with a single future time within the past times` {
+
+        private val severalPastAndFuture = listOf(pastTime(), futureTime(), pastTime())
+
+        @Test
+        fun `throw, if restricted to be in future`() = assertValidationFails {
+            futureSpineTemporals {
+                value.addAll(severalPastAndFuture)
+            }
+        }
+
+        @Test
+        fun `throw, if restricted to be in past`() = assertValidationFails {
+            pastSpineTemporals {
+                value.addAll(severalPastAndFuture)
+            }
+        }
+
+        @Test
+        fun `pass, if not restricted at all`() = assertValidationPasses {
+            anySpineTemporals {
+                value.addAll(severalPastAndFuture)
+            }
+        }
+    }
+}

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/TemporalWhenMapSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/TemporalWhenMapSpec.kt
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("If used with a map of Spine `Temporal` values, `(when)` constraint should")
-internal class SpineTemporalWhenMapSpec {
+internal class TemporalWhenMapSpec {
 
     @Nested inner class
     `when given a map with temporals denoting` {

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/TemporalWhenMapSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/TemporalWhenMapSpec.kt
@@ -39,86 +39,82 @@ import org.junit.jupiter.api.Test
 internal class TemporalWhenMapSpec {
 
     @Nested inner class
-    `when given a map with temporals denoting` {
+    `only the past` {
 
-        @Nested inner class
-        `only the past` {
+        private val severalPastTimes = mapOf("a" to pastTime(), "b" to pastTime())
 
-            private val severalPastTimes = mapOf("a" to pastTime(), "b" to pastTime())
-
-            @Test
-            fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporalMap {
-                    value.putAll(severalPastTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if restricted to be in past`() = assertValidationPasses {
-                pastSpineTemporalMap {
-                    value.putAll(severalPastTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporalMap {
-                    value.putAll(severalPastTimes)
-                }
+        @Test
+        fun `throw, if restricted to be in future`() = assertValidationFails {
+            futureSpineTemporalMap {
+                value.putAll(severalPastTimes)
             }
         }
 
-        @Nested inner class
-        `only the future` {
-
-            private val severalFutureTimes = mapOf("a" to futureTime(), "b" to futureTime())
-
-            @Test
-            fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporalMap {
-                    value.putAll(severalFutureTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if restricted to be in future`() = assertValidationPasses {
-                futureSpineTemporalMap {
-                    value.putAll(severalFutureTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporalMap {
-                    value.putAll(severalFutureTimes)
-                }
+        @Test
+        fun `pass, if restricted to be in past`() = assertValidationPasses {
+            pastSpineTemporalMap {
+                value.putAll(severalPastTimes)
             }
         }
 
-        @Nested inner class
-        `a mix of past and future` {
-
-            private val mixedTimes = mapOf("a" to futureTime(), "b" to pastTime())
-
-            @Test
-            fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporalMap {
-                    value.putAll(mixedTimes)
-                }
+        @Test
+        fun `pass, if not restricted at all`() = assertValidationPasses {
+            anySpineTemporalMap {
+                value.putAll(severalPastTimes)
             }
+        }
+    }
 
-            @Test
-            fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporalMap {
-                    value.putAll(mixedTimes)
-                }
+    @Nested inner class
+    `only the future` {
+
+        private val severalFutureTimes = mapOf("a" to futureTime(), "b" to futureTime())
+
+        @Test
+        fun `throw, if restricted to be in past`() = assertValidationFails {
+            pastSpineTemporalMap {
+                value.putAll(severalFutureTimes)
             }
+        }
 
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporalMap {
-                    value.putAll(mixedTimes)
-                }
+        @Test
+        fun `pass, if restricted to be in future`() = assertValidationPasses {
+            futureSpineTemporalMap {
+                value.putAll(severalFutureTimes)
+            }
+        }
+
+        @Test
+        fun `pass, if not restricted at all`() = assertValidationPasses {
+            anySpineTemporalMap {
+                value.putAll(severalFutureTimes)
+            }
+        }
+    }
+
+    @Nested inner class
+    `a mix of past and future` {
+
+        private val mixedTimes = mapOf("a" to futureTime(), "b" to pastTime())
+
+        @Test
+        fun `throw, if restricted to be in future`() = assertValidationFails {
+            futureSpineTemporalMap {
+                value.putAll(mixedTimes)
+            }
+        }
+
+        @Test
+        fun `throw, if restricted to be in past`() = assertValidationFails {
+            pastSpineTemporalMap {
+                value.putAll(mixedTimes)
+            }
+        }
+
+        @Test
+        fun `pass, if not restricted at all`() = assertValidationPasses {
+            anySpineTemporalMap {
+                value.putAll(mixedTimes)
             }
         }
     }

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/TemporalWhenSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/TemporalWhenSpec.kt
@@ -27,182 +27,63 @@
 package io.spine.tools.time.validation.java
 
 import io.spine.test.tools.validate.anySpineTemporal
-import io.spine.test.tools.validate.anySpineTemporals
 import io.spine.test.tools.validate.futureSpineTemporal
-import io.spine.test.tools.validate.futureSpineTemporals
 import io.spine.test.tools.validate.pastSpineTemporal
-import io.spine.test.tools.validate.pastSpineTemporals
 import io.spine.tools.time.validation.java.TemporalFixtures.futureTime
 import io.spine.tools.time.validation.java.TemporalFixtures.pastTime
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@DisplayName("If used with Spine `Temporal`, `(when)` constraint should")
+@DisplayName("If used with `Temporal`, `(when)` constraint should")
 internal class TemporalWhenSpec {
 
     @Nested inner class
-    `when given a temporal denoting` {
+    `the past` {
 
-        @Nested inner class
-        `the past` {
-
-            @Test
-            fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporal {
-                    value = pastTime()
-                }
-            }
-
-            @Test
-            fun `pass, if restricted to be in past`() = assertValidationPasses {
-                pastSpineTemporal {
-                    value = pastTime()
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporal {
-                    value = pastTime()
-                }
+        @Test
+        fun `throw, if restricted to be in future`() = assertValidationFails {
+            futureSpineTemporal {
+                value = pastTime()
             }
         }
 
-        @Nested inner class
-        `the future` {
-
-            @Test
-            fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporal {
-                    value = futureTime()
-                }
+        @Test
+        fun `pass, if restricted to be in past`() = assertValidationPasses {
+            pastSpineTemporal {
+                value = pastTime()
             }
+        }
 
-            @Test
-            fun `pass, if restricted to be in future`() = assertValidationPasses {
-                futureSpineTemporal {
-                    value = futureTime()
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporal {
-                    value = futureTime()
-                }
+        @Test
+        fun `pass, if not restricted at all`() = assertValidationPasses {
+            anySpineTemporal {
+                value = pastTime()
             }
         }
     }
 
     @Nested inner class
-    `when given several times` {
+    `the future` {
 
-        @Nested inner class
-        `denoting only the past` {
-
-            private val severalPastTimes = listOf(pastTime(), pastTime(), pastTime())
-
-            @Test
-            fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporals {
-                    value.addAll(severalPastTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if restricted to be in past`() = assertValidationPasses {
-                pastSpineTemporals {
-                    value.addAll(severalPastTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporals {
-                    value.addAll(severalPastTimes)
-                }
+        @Test
+        fun `throw, if restricted to be in past`() = assertValidationFails {
+            pastSpineTemporal {
+                value = futureTime()
             }
         }
 
-        @Nested inner class
-        `denoting only the future` {
-
-            private val severalFutureTimes = listOf(futureTime(), futureTime(), futureTime())
-
-            @Test
-            fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporals {
-                    value.addAll(severalFutureTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if restricted to be in future`() = assertValidationPasses {
-                futureSpineTemporals {
-                    value.addAll(severalFutureTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporals {
-                    value.addAll(severalFutureTimes)
-                }
+        @Test
+        fun `pass, if restricted to be in future`() = assertValidationPasses {
+            futureSpineTemporal {
+                value = futureTime()
             }
         }
 
-        @Nested inner class
-        `with a single past time within the future times` {
-
-            private val severalFutureAndPast = listOf(futureTime(), pastTime(), futureTime())
-
-            @Test
-            fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporals {
-                    value.addAll(severalFutureAndPast)
-                }
-            }
-
-            @Test
-            fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporals {
-                    value.addAll(severalFutureAndPast)
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporals {
-                    value.addAll(severalFutureAndPast)
-                }
-            }
-        }
-
-        @Nested inner class
-        `with a single future time within the past times` {
-
-            private val severalPastAndFuture = listOf(pastTime(), futureTime(), pastTime())
-
-            @Test
-            fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporals {
-                    value.addAll(severalPastAndFuture)
-                }
-            }
-
-            @Test
-            fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporals {
-                    value.addAll(severalPastAndFuture)
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporals {
-                    value.addAll(severalPastAndFuture)
-                }
+        @Test
+        fun `pass, if not restricted at all`() = assertValidationPasses {
+            anySpineTemporal {
+                value = futureTime()
             }
         }
     }

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/TemporalWhenSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/TemporalWhenSpec.kt
@@ -26,44 +26,44 @@
 
 package io.spine.tools.time.validation.java
 
-import io.spine.test.tools.validate.anyProtoTimestamp
-import io.spine.test.tools.validate.anyProtoTimestamps
-import io.spine.test.tools.validate.futureProtoTimestamp
-import io.spine.test.tools.validate.futureProtoTimestamps
-import io.spine.test.tools.validate.pastProtoTimestamp
-import io.spine.test.tools.validate.pastProtoTimestamps
-import io.spine.tools.time.validation.java.TimestampFixtures.futureTime
-import io.spine.tools.time.validation.java.TimestampFixtures.pastTime
+import io.spine.test.tools.validate.anySpineTemporal
+import io.spine.test.tools.validate.anySpineTemporals
+import io.spine.test.tools.validate.futureSpineTemporal
+import io.spine.test.tools.validate.futureSpineTemporals
+import io.spine.test.tools.validate.pastSpineTemporal
+import io.spine.test.tools.validate.pastSpineTemporals
+import io.spine.tools.time.validation.java.TemporalFixtures.futureTime
+import io.spine.tools.time.validation.java.TemporalFixtures.pastTime
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@DisplayName("If used with Protobuf `Timestamp`, `(when)` constrain should")
-internal class ProtoTimestampWhenSpec {
+@DisplayName("If used with Spine `Temporal`, `(when)` constraint should")
+internal class TemporalWhenSpec {
 
     @Nested inner class
-    `when given a timestamp denoting` {
+    `when given a temporal denoting` {
 
         @Nested inner class
         `the past` {
 
             @Test
             fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureProtoTimestamp {
+                futureSpineTemporal {
                     value = pastTime()
                 }
             }
 
             @Test
             fun `pass, if restricted to be in past`() = assertValidationPasses {
-                pastProtoTimestamp {
+                pastSpineTemporal {
                     value = pastTime()
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anyProtoTimestamp {
+                anySpineTemporal {
                     value = pastTime()
                 }
             }
@@ -74,21 +74,21 @@ internal class ProtoTimestampWhenSpec {
 
             @Test
             fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastProtoTimestamp {
+                pastSpineTemporal {
                     value = futureTime()
                 }
             }
 
             @Test
             fun `pass, if restricted to be in future`() = assertValidationPasses {
-                futureProtoTimestamp {
+                futureSpineTemporal {
                     value = futureTime()
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anyProtoTimestamp {
+                anySpineTemporal {
                     value = futureTime()
                 }
             }
@@ -96,7 +96,7 @@ internal class ProtoTimestampWhenSpec {
     }
 
     @Nested inner class
-    `when given several timestamps` {
+    `when given several times` {
 
         @Nested inner class
         `denoting only the past` {
@@ -105,21 +105,21 @@ internal class ProtoTimestampWhenSpec {
 
             @Test
             fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureProtoTimestamps {
+                futureSpineTemporals {
                     value.addAll(severalPastTimes)
                 }
             }
 
             @Test
             fun `pass, if restricted to be in past`() = assertValidationPasses {
-                pastProtoTimestamps {
+                pastSpineTemporals {
                     value.addAll(severalPastTimes)
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anyProtoTimestamps {
+                anySpineTemporals {
                     value.addAll(severalPastTimes)
                 }
             }
@@ -132,75 +132,75 @@ internal class ProtoTimestampWhenSpec {
 
             @Test
             fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastProtoTimestamps {
+                pastSpineTemporals {
                     value.addAll(severalFutureTimes)
                 }
             }
 
             @Test
             fun `pass, if restricted to be in future`() = assertValidationPasses {
-                futureProtoTimestamps {
+                futureSpineTemporals {
                     value.addAll(severalFutureTimes)
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anyProtoTimestamps {
+                anySpineTemporals {
                     value.addAll(severalFutureTimes)
                 }
             }
         }
 
         @Nested inner class
-        `with a single past stamp within the future stamps` {
+        `with a single past time within the future times` {
 
             private val severalFutureAndPast = listOf(futureTime(), pastTime(), futureTime())
 
             @Test
             fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureProtoTimestamps {
+                futureSpineTemporals {
                     value.addAll(severalFutureAndPast)
                 }
             }
 
             @Test
             fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastProtoTimestamps {
+                pastSpineTemporals {
                     value.addAll(severalFutureAndPast)
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anyProtoTimestamps {
+                anySpineTemporals {
                     value.addAll(severalFutureAndPast)
                 }
             }
         }
 
         @Nested inner class
-        `with a single future stamp within the past stamps` {
+        `with a single future time within the past times` {
 
             private val severalPastAndFuture = listOf(pastTime(), futureTime(), pastTime())
 
             @Test
             fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureProtoTimestamps {
+                futureSpineTemporals {
                     value.addAll(severalPastAndFuture)
                 }
             }
 
             @Test
             fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastProtoTimestamps {
+                pastSpineTemporals {
                     value.addAll(severalPastAndFuture)
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anyProtoTimestamps {
+                anySpineTemporals {
                     value.addAll(severalPastAndFuture)
                 }
             }

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/TimestampRepeatedWhenSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/TimestampRepeatedWhenSpec.kt
@@ -26,98 +26,125 @@
 
 package io.spine.tools.time.validation.java
 
-import io.spine.test.tools.validate.anySpineTemporalMap
-import io.spine.test.tools.validate.futureSpineTemporalMap
-import io.spine.test.tools.validate.pastSpineTemporalMap
-import io.spine.tools.time.validation.java.TemporalFixtures.futureTime
-import io.spine.tools.time.validation.java.TemporalFixtures.pastTime
+import io.spine.test.tools.validate.anyProtoTimestamps
+import io.spine.test.tools.validate.futureProtoTimestamps
+import io.spine.test.tools.validate.pastProtoTimestamps
+import io.spine.tools.time.validation.java.TimestampFixtures.futureTime
+import io.spine.tools.time.validation.java.TimestampFixtures.pastTime
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@DisplayName("If used with a map of `Temporal` values, `(when)` constraint should")
-internal class TemporalWhenMapSpec {
+@DisplayName("If used with repeated Protobuf `Timestamp`, `(when)` constraint should")
+internal class TimestampRepeatedWhenSpec {
 
     @Nested inner class
-    `when given a map with temporals denoting` {
+    `when given several timestamps` {
 
         @Nested inner class
-        `only the past` {
+        `denoting only the past` {
 
-            private val severalPastTimes = mapOf("a" to pastTime(), "b" to pastTime())
+            private val severalPastTimes = listOf(pastTime(), pastTime(), pastTime())
 
             @Test
             fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporalMap {
-                    value.putAll(severalPastTimes)
+                futureProtoTimestamps {
+                    value.addAll(severalPastTimes)
                 }
             }
 
             @Test
             fun `pass, if restricted to be in past`() = assertValidationPasses {
-                pastSpineTemporalMap {
-                    value.putAll(severalPastTimes)
+                pastProtoTimestamps {
+                    value.addAll(severalPastTimes)
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporalMap {
-                    value.putAll(severalPastTimes)
+                anyProtoTimestamps {
+                    value.addAll(severalPastTimes)
                 }
             }
         }
 
         @Nested inner class
-        `only the future` {
+        `denoting only the future` {
 
-            private val severalFutureTimes = mapOf("a" to futureTime(), "b" to futureTime())
+            private val severalFutureTimes = listOf(futureTime(), futureTime(), futureTime())
 
             @Test
             fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporalMap {
-                    value.putAll(severalFutureTimes)
+                pastProtoTimestamps {
+                    value.addAll(severalFutureTimes)
                 }
             }
 
             @Test
             fun `pass, if restricted to be in future`() = assertValidationPasses {
-                futureSpineTemporalMap {
-                    value.putAll(severalFutureTimes)
+                futureProtoTimestamps {
+                    value.addAll(severalFutureTimes)
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporalMap {
-                    value.putAll(severalFutureTimes)
+                anyProtoTimestamps {
+                    value.addAll(severalFutureTimes)
                 }
             }
         }
 
         @Nested inner class
-        `a mix of past and future` {
+        `with a single past stamp within the future stamps` {
 
-            private val mixedTimes = mapOf("a" to futureTime(), "b" to pastTime())
+            private val severalFutureAndPast = listOf(futureTime(), pastTime(), futureTime())
 
             @Test
             fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporalMap {
-                    value.putAll(mixedTimes)
+                futureProtoTimestamps {
+                    value.addAll(severalFutureAndPast)
                 }
             }
 
             @Test
             fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporalMap {
-                    value.putAll(mixedTimes)
+                pastProtoTimestamps {
+                    value.addAll(severalFutureAndPast)
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporalMap {
-                    value.putAll(mixedTimes)
+                anyProtoTimestamps {
+                    value.addAll(severalFutureAndPast)
+                }
+            }
+        }
+
+        @Nested inner class
+        `with a single future stamp within the past stamps` {
+
+            private val severalPastAndFuture = listOf(pastTime(), futureTime(), pastTime())
+
+            @Test
+            fun `throw, if restricted to be in future`() = assertValidationFails {
+                futureProtoTimestamps {
+                    value.addAll(severalPastAndFuture)
+                }
+            }
+
+            @Test
+            fun `throw, if restricted to be in past`() = assertValidationFails {
+                pastProtoTimestamps {
+                    value.addAll(severalPastAndFuture)
+                }
+            }
+
+            @Test
+            fun `pass, if not restricted at all`() = assertValidationPasses {
+                anyProtoTimestamps {
+                    value.addAll(severalPastAndFuture)
                 }
             }
         }

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/TimestampWhenMapSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/TimestampWhenMapSpec.kt
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("If used with a map of Protobuf `Timestamp` values, `(when)` constraint should")
-internal class ProtoTimestampWhenMapSpec {
+internal class TimestampWhenMapSpec {
 
     @Nested inner class
     `when given a map with timestamps denoting` {

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/TimestampWhenSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/TimestampWhenSpec.kt
@@ -27,18 +27,15 @@
 package io.spine.tools.time.validation.java
 
 import io.spine.test.tools.validate.anyProtoTimestamp
-import io.spine.test.tools.validate.anyProtoTimestamps
 import io.spine.test.tools.validate.futureProtoTimestamp
-import io.spine.test.tools.validate.futureProtoTimestamps
 import io.spine.test.tools.validate.pastProtoTimestamp
-import io.spine.test.tools.validate.pastProtoTimestamps
 import io.spine.tools.time.validation.java.TimestampFixtures.futureTime
 import io.spine.tools.time.validation.java.TimestampFixtures.pastTime
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@DisplayName("If used with Protobuf `Timestamp`, `(when)` constrain should")
+@DisplayName("If used with Protobuf `Timestamp`, `(when)` constraint should")
 internal class TimestampWhenSpec {
 
     @Nested inner class
@@ -90,118 +87,6 @@ internal class TimestampWhenSpec {
             fun `pass, if not restricted at all`() = assertValidationPasses {
                 anyProtoTimestamp {
                     value = futureTime()
-                }
-            }
-        }
-    }
-
-    @Nested inner class
-    `when given several timestamps` {
-
-        @Nested inner class
-        `denoting only the past` {
-
-            private val severalPastTimes = listOf(pastTime(), pastTime(), pastTime())
-
-            @Test
-            fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureProtoTimestamps {
-                    value.addAll(severalPastTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if restricted to be in past`() = assertValidationPasses {
-                pastProtoTimestamps {
-                    value.addAll(severalPastTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anyProtoTimestamps {
-                    value.addAll(severalPastTimes)
-                }
-            }
-        }
-
-        @Nested inner class
-        `denoting only the future` {
-
-            private val severalFutureTimes = listOf(futureTime(), futureTime(), futureTime())
-
-            @Test
-            fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastProtoTimestamps {
-                    value.addAll(severalFutureTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if restricted to be in future`() = assertValidationPasses {
-                futureProtoTimestamps {
-                    value.addAll(severalFutureTimes)
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anyProtoTimestamps {
-                    value.addAll(severalFutureTimes)
-                }
-            }
-        }
-
-        @Nested inner class
-        `with a single past stamp within the future stamps` {
-
-            private val severalFutureAndPast = listOf(futureTime(), pastTime(), futureTime())
-
-            @Test
-            fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureProtoTimestamps {
-                    value.addAll(severalFutureAndPast)
-                }
-            }
-
-            @Test
-            fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastProtoTimestamps {
-                    value.addAll(severalFutureAndPast)
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anyProtoTimestamps {
-                    value.addAll(severalFutureAndPast)
-                }
-            }
-        }
-
-        @Nested inner class
-        `with a single future stamp within the past stamps` {
-
-            private val severalPastAndFuture = listOf(pastTime(), futureTime(), pastTime())
-
-            @Test
-            fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureProtoTimestamps {
-                    value.addAll(severalPastAndFuture)
-                }
-            }
-
-            @Test
-            fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastProtoTimestamps {
-                    value.addAll(severalPastAndFuture)
-                }
-            }
-
-            @Test
-            fun `pass, if not restricted at all`() = assertValidationPasses {
-                anyProtoTimestamps {
-                    value.addAll(severalPastAndFuture)
                 }
             }
         }

--- a/tests/src/test/kotlin/io/spine/tools/time/validation/java/TimestampWhenSpec.kt
+++ b/tests/src/test/kotlin/io/spine/tools/time/validation/java/TimestampWhenSpec.kt
@@ -26,44 +26,44 @@
 
 package io.spine.tools.time.validation.java
 
-import io.spine.test.tools.validate.anySpineTemporal
-import io.spine.test.tools.validate.anySpineTemporals
-import io.spine.test.tools.validate.futureSpineTemporal
-import io.spine.test.tools.validate.futureSpineTemporals
-import io.spine.test.tools.validate.pastSpineTemporal
-import io.spine.test.tools.validate.pastSpineTemporals
-import io.spine.tools.time.validation.java.TemporalFixtures.futureTime
-import io.spine.tools.time.validation.java.TemporalFixtures.pastTime
+import io.spine.test.tools.validate.anyProtoTimestamp
+import io.spine.test.tools.validate.anyProtoTimestamps
+import io.spine.test.tools.validate.futureProtoTimestamp
+import io.spine.test.tools.validate.futureProtoTimestamps
+import io.spine.test.tools.validate.pastProtoTimestamp
+import io.spine.test.tools.validate.pastProtoTimestamps
+import io.spine.tools.time.validation.java.TimestampFixtures.futureTime
+import io.spine.tools.time.validation.java.TimestampFixtures.pastTime
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@DisplayName("If used with Spine `Temporal`, `(when)` constraint should")
-internal class SpineTemporalWhenSpec {
+@DisplayName("If used with Protobuf `Timestamp`, `(when)` constrain should")
+internal class TimestampWhenSpec {
 
     @Nested inner class
-    `when given a temporal denoting` {
+    `when given a timestamp denoting` {
 
         @Nested inner class
         `the past` {
 
             @Test
             fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporal {
+                futureProtoTimestamp {
                     value = pastTime()
                 }
             }
 
             @Test
             fun `pass, if restricted to be in past`() = assertValidationPasses {
-                pastSpineTemporal {
+                pastProtoTimestamp {
                     value = pastTime()
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporal {
+                anyProtoTimestamp {
                     value = pastTime()
                 }
             }
@@ -74,21 +74,21 @@ internal class SpineTemporalWhenSpec {
 
             @Test
             fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporal {
+                pastProtoTimestamp {
                     value = futureTime()
                 }
             }
 
             @Test
             fun `pass, if restricted to be in future`() = assertValidationPasses {
-                futureSpineTemporal {
+                futureProtoTimestamp {
                     value = futureTime()
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporal {
+                anyProtoTimestamp {
                     value = futureTime()
                 }
             }
@@ -96,7 +96,7 @@ internal class SpineTemporalWhenSpec {
     }
 
     @Nested inner class
-    `when given several times` {
+    `when given several timestamps` {
 
         @Nested inner class
         `denoting only the past` {
@@ -105,21 +105,21 @@ internal class SpineTemporalWhenSpec {
 
             @Test
             fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporals {
+                futureProtoTimestamps {
                     value.addAll(severalPastTimes)
                 }
             }
 
             @Test
             fun `pass, if restricted to be in past`() = assertValidationPasses {
-                pastSpineTemporals {
+                pastProtoTimestamps {
                     value.addAll(severalPastTimes)
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporals {
+                anyProtoTimestamps {
                     value.addAll(severalPastTimes)
                 }
             }
@@ -132,75 +132,75 @@ internal class SpineTemporalWhenSpec {
 
             @Test
             fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporals {
+                pastProtoTimestamps {
                     value.addAll(severalFutureTimes)
                 }
             }
 
             @Test
             fun `pass, if restricted to be in future`() = assertValidationPasses {
-                futureSpineTemporals {
+                futureProtoTimestamps {
                     value.addAll(severalFutureTimes)
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporals {
+                anyProtoTimestamps {
                     value.addAll(severalFutureTimes)
                 }
             }
         }
 
         @Nested inner class
-        `with a single past time within the future times` {
+        `with a single past stamp within the future stamps` {
 
             private val severalFutureAndPast = listOf(futureTime(), pastTime(), futureTime())
 
             @Test
             fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporals {
+                futureProtoTimestamps {
                     value.addAll(severalFutureAndPast)
                 }
             }
 
             @Test
             fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporals {
+                pastProtoTimestamps {
                     value.addAll(severalFutureAndPast)
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporals {
+                anyProtoTimestamps {
                     value.addAll(severalFutureAndPast)
                 }
             }
         }
 
         @Nested inner class
-        `with a single future time within the past times` {
+        `with a single future stamp within the past stamps` {
 
             private val severalPastAndFuture = listOf(pastTime(), futureTime(), pastTime())
 
             @Test
             fun `throw, if restricted to be in future`() = assertValidationFails {
-                futureSpineTemporals {
+                futureProtoTimestamps {
                     value.addAll(severalPastAndFuture)
                 }
             }
 
             @Test
             fun `throw, if restricted to be in past`() = assertValidationFails {
-                pastSpineTemporals {
+                pastProtoTimestamps {
                     value.addAll(severalPastAndFuture)
                 }
             }
 
             @Test
             fun `pass, if not restricted at all`() = assertValidationPasses {
-                anySpineTemporals {
+                anyProtoTimestamps {
                     value.addAll(severalPastAndFuture)
                 }
             }

--- a/tests/src/testFixtures/proto/spine/test/tools/validate/when_map.proto
+++ b/tests/src/testFixtures/proto/spine/test/tools/validate/when_map.proto
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine.test.tools.validate;
+
+import "spine/options.proto";
+import "spine/time_options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.tools.validate";
+option java_outer_classname = "WhenMapProto";
+option java_multiple_files = true;
+
+import "google/protobuf/timestamp.proto";
+import "spine/time/time.proto";
+
+// Tests `PAST` restriction with a map of Protobuf timestamps.
+message PastProtoTimestampMap {
+    map<string, google.protobuf.Timestamp> value = 1 [(when).in = PAST];
+}
+
+// Tests `PAST` restriction with a map of Spine temporals.
+message PastSpineTemporalMap {
+    map<string, spine.time.LocalDateTime> value = 1 [(when).in = PAST];
+}
+
+// Tests `FUTURE` restriction with a map of Protobuf timestamps.
+message FutureProtoTimestampMap {
+    map<string, google.protobuf.Timestamp> value = 1 [(when).in = FUTURE];
+}
+
+// Tests `FUTURE` restriction with a map of Spine temporals.
+message FutureSpineTemporalMap {
+    map<string, spine.time.LocalDateTime> value = 1 [(when).in = FUTURE];
+}
+
+// Tests that a map of Protobuf timestamps is not restricted when there's no option.
+message AnyProtoTimestampMap {
+    map<string, google.protobuf.Timestamp> value = 1;
+}
+
+// Tests that a map of Spine temporals is not restricted when there's no option.
+message AnySpineTemporalMap {
+    map<string, spine.time.LocalDateTime> value = 1;
+}

--- a/validation/src/main/kotlin/io/spine/tools/time/validation/java/WhenGenerator.kt
+++ b/validation/src/main/kotlin/io/spine/tools/time/validation/java/WhenGenerator.kt
@@ -30,6 +30,7 @@ import io.spine.base.FieldPath
 import io.spine.server.query.select
 import io.spine.time.validation.Time.FUTURE
 import io.spine.tools.compiler.ast.TypeName
+import io.spine.tools.compiler.ast.isMap
 import io.spine.tools.compiler.ast.isRepeatedMessage
 import io.spine.tools.compiler.ast.name
 import io.spine.tools.compiler.jvm.CodeBlock
@@ -108,6 +109,15 @@ private class GenerateWhen(
             CodeBlock(
                 """
                 for (var element : $fieldValue) {
+                    ${validateTime(ReadVar("element"))}
+                }
+                """.trimIndent()
+            )
+
+        fieldType.isMap ->
+            CodeBlock(
+                """
+                for (var element : $fieldValue.values()) {
                     ${validateTime(ReadVar("element"))}
                 }
                 """.trimIndent()

--- a/validation/src/main/kotlin/io/spine/tools/time/validation/java/WhenOption.kt
+++ b/validation/src/main/kotlin/io/spine/tools/time/validation/java/WhenOption.kt
@@ -47,6 +47,7 @@ import io.spine.tools.compiler.ast.FieldType
 import io.spine.tools.compiler.ast.File
 import io.spine.tools.compiler.ast.event.FieldOptionDiscovered
 import io.spine.tools.compiler.ast.extractMessageType
+import io.spine.tools.compiler.ast.isMap
 import io.spine.tools.compiler.ast.isRepeatedMessage
 import io.spine.tools.compiler.ast.name
 import io.spine.tools.compiler.ast.qualifiedName
@@ -161,7 +162,7 @@ private fun checkFieldType(field: Field, typeSystem: TypeSystem, file: File): Ti
  * For other field types, the method returns [TimeFieldType.TFT_UNKNOWN].
  */
 private fun TypeSystem.determineTimeType(fieldType: FieldType): TimeFieldType {
-    if (!fieldType.isMessage && !fieldType.isRepeatedMessage) {
+    if (!fieldType.isMessage && !fieldType.isRepeatedMessage && !fieldType.isMap) {
         return TFT_UNKNOWN
     }
     val messageType = fieldType.extractMessageType(typeSystem = this)?.name

--- a/validation/src/main/kotlin/io/spine/tools/time/validation/java/WhenOption.kt
+++ b/validation/src/main/kotlin/io/spine/tools/time/validation/java/WhenOption.kt
@@ -156,7 +156,7 @@ private fun checkFieldType(field: Field, typeSystem: TypeSystem, file: File): Ti
 }
 
 /**
- * Analysis the given [fieldType], determining whether it represents
+ * Analyses the given [fieldType], determining whether it represents
  * the Protobuf [Timestamp] or Spine [Temporal].
  *
  * For other field types, the method returns [TimeFieldType.TFT_UNKNOWN].

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library for publishing.
  */
-val versionToPublish by extra("2.0.0-SNAPSHOT.236")
+val versionToPublish by extra("2.0.0-SNAPSHOT.237")


### PR DESCRIPTION
This PR extends the `validation` module with the support of map values constrained with the `(when)` option.

### Other notable changes
 * Test suites under the `test` were split by types of the checked fields.
 * Latest `config` was applied.
