### PR TITLE
Use `VIEW` alias for an entity kind

### DIFF
--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   build:
     runs-on: windows-latest
-    name: Build and test on Windows
+    name: Build on Windows
 
     steps:
       - uses: actions/checkout@v4

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:time-gradle-plugin:2.0.0-SNAPSHOT.239`
+# Dependencies of `io.spine.tools:time-gradle-plugin:2.0.0-SNAPSHOT.240`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -1059,14 +1059,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 04 18:52:51 WEST 2026** using 
+This report was generated on **Mon May 04 20:23:34 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:time-testlib:2.0.0-SNAPSHOT.239`
+# Dependencies of `io.spine.tools:time-testlib:2.0.0-SNAPSHOT.240`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1869,14 +1869,14 @@ This report was generated on **Mon May 04 18:52:51 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 04 18:52:51 WEST 2026** using 
+This report was generated on **Mon May 04 20:23:34 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.239`
+# Dependencies of `io.spine:spine-time:2.0.0-SNAPSHOT.240`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2833,14 +2833,14 @@ This report was generated on **Mon May 04 18:52:51 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 04 18:52:51 WEST 2026** using 
+This report was generated on **Mon May 04 20:23:34 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.239`
+# Dependencies of `io.spine:spine-time-java:2.0.0-SNAPSHOT.240`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3643,14 +3643,14 @@ This report was generated on **Mon May 04 18:52:51 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 04 18:52:51 WEST 2026** using 
+This report was generated on **Mon May 04 20:23:34 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.239`
+# Dependencies of `io.spine:spine-time-kotlin:2.0.0-SNAPSHOT.240`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4461,14 +4461,14 @@ This report was generated on **Mon May 04 18:52:51 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 04 18:52:51 WEST 2026** using 
+This report was generated on **Mon May 04 20:23:34 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:time-validation:2.0.0-SNAPSHOT.239`
+# Dependencies of `io.spine.tools:time-validation:2.0.0-SNAPSHOT.240`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -5590,14 +5590,14 @@ This report was generated on **Mon May 04 18:52:51 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 04 18:52:51 WEST 2026** using 
+This report was generated on **Mon May 04 20:23:34 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-validation-tests:2.0.0-SNAPSHOT.239`
+# Dependencies of `io.spine:spine-validation-tests:2.0.0-SNAPSHOT.240`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -6683,6 +6683,6 @@ This report was generated on **Mon May 04 18:52:51 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon May 04 18:52:51 WEST 2026** using 
+This report was generated on **Mon May 04 20:23:34 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-time</artifactId>
-<version>2.0.0-SNAPSHOT.239</version>
+<version>2.0.0-SNAPSHOT.240</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/validation/src/main/proto/spine/tools/time/validation/views.proto
+++ b/validation/src/main/proto/spine/tools/time/validation/views.proto
@@ -41,7 +41,7 @@ import "spine/tools/time/validation/time_field_type.proto";
 
 // A view of a field that is marked with `(when)` option.
 message WhenField {
-    option (entity).kind = PROJECTION;
+    option (entity).kind = VIEW;
 
     spine.compiler.FieldRef id = 1;
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library for publishing.
  */
-val versionToPublish by extra("2.0.0-SNAPSHOT.239")
+val versionToPublish by extra("2.0.0-SNAPSHOT.240")


### PR DESCRIPTION
This PR updates the `WhenField` proto type so that it uses `VIEW` alias for the `(entity).kind`. It would read simpler in the Validation documentation.

Also, the PR shortens the GitHub workflow when building on Windows.